### PR TITLE
add support for building with nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,41 @@
+{ package ? "ip", compiler ? "ghc822" }:
+
+let
+  fetchNixpkgs = import ./nix/fetchNixpkgs.nix;
+  nixpkgs = fetchNixpkgs {
+    rev = "e5629dc51a313c3b99725616718d2deff49cd891";
+    sha256 = "0s3a65mswqds5395cqy9d4mj8d75vii2479y4dvyagamv1zh0zp6";
+  };
+  pkgs = import nixpkgs { config = {}; };
+  inherit (pkgs) haskell;
+
+  filterPredicate = p: type:
+    let path = baseNameOf p; in !(
+         (type == "directory" && path == "dist")
+      || (type == "symlink"   && path == "result")
+      || (type == "directory" && path == ".git")
+      || (type == "symlink"   && pkgs.lib.hasPrefix "result" path)
+      || pkgs.lib.hasSuffix "~" path
+      || pkgs.lib.hasSuffix ".o" path
+      || pkgs.lib.hasSuffix ".so" path
+      || pkgs.lib.hasSuffix ".nix" path);
+
+  overrides = haskell.packages.${compiler}.override {
+    overrides = self: super:
+    with haskell.lib;
+    with { cp = file: (self.callPackage (./nix/haskell + "/${file}.nix") {});
+           build = name: path: self.callCabal2nix name (builtins.filterSource filterPredicate path) {};
+         };
+    {
+      mkDerivation = args: super.mkDerivation (args // {
+        doCheck = pkgs.lib.elem args.pname [ "ip" ];
+        doHaddock = false;
+      });
+
+      ip = build "ip" ./.;
+    };
+  };
+in rec {
+  drv = overrides.${package};
+  ip  = if pkgs.lib.inNixShell then drv.env else drv;
+}

--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -1,0 +1,51 @@
+{ rev                             # The Git revision of nixpkgs to fetch
+, sha256                          # The SHA256 of the downloaded data
+, system ? builtins.currentSystem # This is overridable if necessary
+}:
+
+with {
+  ifThenElse = { bool, thenValue, elseValue }: (
+    if bool then thenValue else elseValue);
+};
+
+ifThenElse {
+  bool = (0 <= builtins.compareVersions builtins.nixVersion "1.12");
+
+  # In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+  thenValue = (
+    builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      inherit sha256;
+    });
+
+  # This hack should at least work for Nix 1.11
+  elseValue = (
+    (rec {
+      tarball = import <nix/fetchurl.nix> {
+        url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+        inherit sha256;
+      };
+
+      builtin-paths = import <nix/config.nix>;
+      
+      script = builtins.toFile "nixpkgs-unpacker" ''
+        "$coreutils/mkdir" "$out"
+        cd "$out"
+        "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+      '';
+
+      nixpkgs = builtins.derivation {
+        name = "nixpkgs-${builtins.substring 0 6 rev}";
+
+        builder = builtins.storePath builtin-paths.shell;
+
+        args = [ script ];
+
+        inherit tarball system;
+
+        tar       = builtins.storePath builtin-paths.tar;
+        gzip      = builtins.storePath builtin-paths.gzip;
+        coreutils = builtins.storePath builtin-paths.coreutils;
+      };
+    }).nixpkgs);
+}


### PR DESCRIPTION
spreading the infection.
build with nix-shell -A ip --run "cabal repl"

This does not interfere with anything other than allowing the ability to build easily with nix.