### PR TITLE
add print functions & get rid of most warnings

### DIFF
--- a/src/Data/Text/Builder/Common/Internal.hs
+++ b/src/Data/Text/Builder/Common/Internal.hs
@@ -3,22 +3,11 @@ module Data.Text.Builder.Common.Internal where
 import Data.Text (Text)
 import Control.Monad.ST
 import Data.Monoid
-import Data.Word
-import Data.Bits
 import Text.Printf
-import Debug.Trace
 import Data.Char (ord)
-import Data.Vector (Vector)
 import Data.Foldable (fold)
-import qualified Data.Vector as Vector
 import qualified Data.Text as Text
-import qualified Data.Text.Lazy as LText
-import qualified Data.Text.Lazy.IO as LText
-import qualified Data.Text.Lazy.Builder as TBuilder
-import qualified Data.Text.Lazy.Builder.Int as TBuilder
-import qualified Data.Text.IO as Text
 import qualified Data.Text.Array as A
-import qualified Data.Text.Internal as TI
 import qualified Data.Text.Internal.Unsafe.Char as TC
 
 -- | This is slower that just pattern matching on the Text data constructor.

--- a/src/Data/Text/Builder/Variable.hs
+++ b/src/Data/Text/Builder/Variable.hs
@@ -22,17 +22,13 @@ module Data.Text.Builder.Variable
   , word8
   ) where
 
-import Data.Monoid
 import Data.Word
 import Data.Text (Text)
-import Text.Printf (printf)
 import Control.Monad.ST
 import Data.Char (ord)
 import Data.Vector (Vector)
-import Data.Function (on)
 import Data.Maybe (fromMaybe)
 import qualified Data.Vector as Vector
-import qualified Data.Text as Text
 import qualified Data.Text.Array as A
 import qualified Data.Text.Builder.Common.Internal as I
 import qualified Data.Text.Internal as TI
@@ -112,7 +108,7 @@ vector tDef v =
       xDef = I.portableUntext tDef
    in Builder
         (Vector.maximum $ Vector.map I.portableTextLength $ Vector.cons tDef v)
-        $ \pos marr i -> do
+        $ \_ marr i -> do
           let (arr,len) = fromMaybe xDef (xs Vector.!? i)
               finalIx = i + len
           A.copyI marr i arr 0 finalIx

--- a/src/Net/IP.hs
+++ b/src/Net/IP.hs
@@ -36,10 +36,13 @@ module Net.IP
     -- ** Text
   , encode
   , decode
+    -- ** Printing
+  , print
     -- * Types
   , IP(..)
   ) where
 
+import Prelude hiding (print)
 import Data.Bits
 import Net.IPv6 (IPv6(..))
 import Net.IPv4 (IPv4(..))
@@ -51,6 +54,7 @@ import Data.Word (Word8,Word16)
 import qualified Net.IPv4 as IPv4
 import qualified Net.IPv6 as IPv6
 import qualified Data.Aeson as Aeson
+import qualified Data.Text.IO as TIO
 
 case_ :: (IPv4 -> a) -> (IPv6 -> a) -> IP -> a
 case_ f g (IP addr@(IPv6 w1 w2)) = if w1 == 0 && (0xFFFFFFFF00000000 .&. w2 == 0x0000FFFF00000000)
@@ -84,6 +88,9 @@ decode t = case IPv4.decode t of
     Nothing -> Nothing
     Just v6 -> Just (fromIPv6 v6)
   Just v4 -> Just (fromIPv4 v4)
+
+print :: IP -> IO ()
+print = TIO.putStrLn . encode
 
 -- | A 32-bit 'IPv4' address or a 128-bit 'IPv6' address. Internally, this
 --   is just represented as an 'IPv6' address. The functions provided

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -40,7 +40,7 @@ module Net.IPv4
   , decode
   , builder
   , reader
-  , parser
+  , parser 
     -- ** UTF-8 ByteString
   , encodeUtf8
   , decodeUtf8
@@ -50,11 +50,13 @@ module Net.IPv4
     -- $string
   , encodeString
   , decodeString
+    -- ** Printing
+  , print
     -- * Types
   , IPv4(..)
   ) where
 
-import Prelude hiding (any)
+import Prelude hiding (any, print)
 import Data.Bits ((.&.),(.|.),shiftR,shiftL,unsafeShiftR)
 import Data.Word
 import Data.Hashable
@@ -94,6 +96,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString.Builder as BB
 import qualified Data.Text.Array as TArray
+import qualified Data.Text.IO as TIO
 
 #if MIN_VERSION_aeson(1,0,0) 
 import Data.Aeson (ToJSONKey(..),FromJSONKey(..),
@@ -345,6 +348,8 @@ instance Read IPv4 where
     d <- step readPrec
     return (fromOctets a b c d)
     
+print :: IPv4 -> IO ()
+print = TIO.putStrLn . encode
 
 newtype instance UVector.MVector s IPv4 = MV_IPv4 (PVector.MVector s IPv4)
 newtype instance UVector.Vector IPv4 = V_IPv4 (PVector.Vector IPv4)

--- a/src/Net/IPv6.hs
+++ b/src/Net/IPv6.hs
@@ -18,9 +18,11 @@ module Net.IPv6
   , encode
   , decode
   , parser
+    -- ** Printing
+  , print
   ) where
 
-import Prelude hiding (any)
+import Prelude hiding (any, print)
 import Data.Bits
 import Data.List (intercalate, group)
 import Data.Word
@@ -30,6 +32,7 @@ import Data.Text (Text)
 import Text.Read (Read(..),Lexeme(Ident),lexP,parens)
 import Text.ParserCombinators.ReadPrec (prec,step)
 import qualified Data.Text as Text
+import qualified Data.Text.IO as TIO
 import qualified Data.Attoparsec.Text as Atto
 import qualified Data.Aeson as Aeson
 import qualified Data.Attoparsec.Text as AT
@@ -69,6 +72,9 @@ instance Show IPv6 where
     . showHexWord16 h
     where
     (a,b,c,d,e,f,g,h) = toWord16s addr
+
+print :: IPv6 -> IO ()
+print = TIO.putStrLn . encode
 
 showHexWord16 :: Word16 -> ShowS
 showHexWord16 w =

--- a/src/Net/Mac.hs
+++ b/src/Net/Mac.hs
@@ -34,12 +34,15 @@ module Net.Mac
   , parserWithUtf8
     -- ** ByteString
   , decodeBytes
+    -- ** Printing
+  , print
     -- * Types
   , Mac(..)
   , MacCodec(..)
   , MacGrouping(..)
   ) where
 
+import Prelude hiding (print)
 import Data.Word
 import Data.Bits ((.|.),unsafeShiftL,unsafeShiftR,(.&.))
 import Data.Text (Text)
@@ -64,6 +67,7 @@ import qualified Data.Text.Builder.Fixed as TFB
 import qualified Data.ByteString.Builder.Fixed as BFB
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
+import qualified Data.Text.IO as TIO
 
 #if MIN_VERSION_aeson(1,0,0) 
 import Data.Aeson (ToJSONKey(..),FromJSONKey(..),
@@ -555,6 +559,9 @@ instance Read Mac where
     Ident "mac" <- lexP
     w <- step readPrec
     return (mac w)
+
+print :: Mac -> IO ()
+print = TIO.putStrLn . encode
 
 showHexWord48 :: Word64 -> ShowS
 showHexWord48 w = showString "0x" . go 11


### PR DESCRIPTION
I added the print functions mentioned in issue #24. I also made it so that building is not as noisy due to the many warnings, mainly unused imports. I left only one unused-top-binds warning, in src/Data/Text/Builder/Variable.hs, because 'vector' (line 106) is not exported, and I didn't know if you wanted it to be exported, since it was annotated with "this has not been tested yet."