### PR TITLE
IPv4Range Bits and FiniteBits instance

### DIFF
--- a/ip.cabal
+++ b/ip.cabal
@@ -95,6 +95,7 @@ test-suite spec
     , hspec >= 2.4.4 && < 2.5
   other-modules:
     Net.IPv4Spec
+    Net.IPv4.RangeSpec
   ghc-options: -Wall -O2
   default-language: Haskell2010
 

--- a/src/Net/IPv4/Range.hs
+++ b/src/Net/IPv4/Range.hs
@@ -43,6 +43,7 @@ import Data.Aeson (FromJSON(..),ToJSON(..))
 import GHC.Generics (Generic)
 import Data.Monoid ((<>))
 import qualified Net.IPv4 as IPv4
+import qualified Data.Bits as Bits
 import qualified Data.Text.IO as Text
 import qualified Data.Attoparsec.Text as AT
 import qualified Data.Text.Lazy.Builder as TBuilder
@@ -163,12 +164,12 @@ wordSuccessorsM = go where
 -- 192.168.1.11
 
 toList :: IPv4Range -> [IPv4]
-toList (IPv4Range ip len) = 
+toList (IPv4Range ip len) =
   let totalAddrs = countAddrs len
    in wordSuccessors totalAddrs ip
 
 toGenerator :: MonadPlus m => IPv4Range -> m IPv4
-toGenerator (IPv4Range ip len) =  
+toGenerator (IPv4Range ip len) =
   let totalAddrs = countAddrs len
    in wordSuccessorsM totalAddrs ip
 
@@ -365,6 +366,47 @@ instance GVector.Vector UVector.Vector IPv4Range where
   elemseq _ (IPv4Range a b)
       = GVector.elemseq (undefined :: UVector.Vector a) a
         . GVector.elemseq (undefined :: UVector.Vector b) b
+
+rangeBitwise :: (IPv4 -> IPv4 -> IPv4) -> IPv4Range -> IPv4Range -> IPv4Range
+rangeBitwise fun l r = range ip len
+  where
+    -- Normalise first
+    l' = normalize l
+    r' = normalize r
+    ip = (ipv4RangeBase l') `fun` (ipv4RangeBase r')
+    len = maximum [ipv4RangeLength l, ipv4RangeLength r]
+
+rangeRebase :: (IPv4 -> IPv4) -> IPv4Range -> IPv4Range
+rangeRebase fun r = range (fun $ ipv4RangeBase r) (ipv4RangeLength r)
+
+-- | Notes:
+--
+--     * bit operations use network order (big endian),
+--
+--     * do not operate on host bits,
+--
+--     * return a normalized range dropping host bits,
+--
+--     * and "promote operands" by extending the length to the larger of two
+--       ranges.
+--
+instance Bits.Bits IPv4Range where
+  (.&.) = rangeBitwise (.&.)
+  (.|.) = rangeBitwise (.|.)
+  xor = rangeBitwise Bits.xor
+  complement = rangeRebase Bits.complement
+  shift r i = rangeRebase (flip Bits.shift i) r
+  rotate r i = rangeRebase (flip Bits.rotate i) r
+  bitSize = Bits.finiteBitSize
+  bitSizeMaybe = Just . Bits.finiteBitSize
+  isSigned = Bits.isSigned . ipv4RangeBase
+  testBit ip i = Bits.testBit (ipv4RangeBase ip) i
+  bit i = IPv4Range (Bits.bit i) $ fromIntegral $ i + 1
+  popCount = Bits.popCount . ipv4RangeBase . normalize
+
+-- | Note: the size is determined by the range length
+instance Bits.FiniteBits IPv4Range where
+  finiteBitSize = fromIntegral . ipv4RangeLength
 
 -----------------
 -- Internal Stuff

--- a/test/Net/IPv4/RangeSpec.hs
+++ b/test/Net/IPv4/RangeSpec.hs
@@ -1,0 +1,68 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+module Net.IPv4.RangeSpec (spec) where
+import Prelude hiding (any)
+import Data.Bits
+import Net.IPv4
+import Net.IPv4.Range
+import Test.Hspec
+
+spec :: Spec
+spec = parallel $ do
+  describe "Bits" $ do
+    context "underlying IPv4 imlementation used correctly" $ do
+      let host = range (ipv4 255 255 0 0) 32
+          broadH = range broadcast 32
+          negBroadH = range (ipv4 0 0 255 255) 32
+      it ".&." $ do
+        host .&. broadH `shouldBe` host
+      it ".|." $ do
+        host .|. broadH `shouldBe` broadH
+      it "xor" $ do
+        host `xor` broadH `shouldBe` negBroadH
+      it "complement" $ do
+        complement host `shouldBe` negBroadH
+      it "shift" $ do
+        shift host 8 `shouldBe` range (ipv4 255 0 0 0) 32
+      it "rotate" $ do
+        rotate host 8 `shouldBe` range (ipv4 255 0 0 255) 32
+      it "isSigned" $ do
+        isSigned host `shouldBe` False
+    context "size operations use length correctly" $ do
+      it "bitSize" $ do
+          bitSize (range any 8) `shouldBe` 8
+          bitSize (range any 15) `shouldBe` 15
+          bitSize (range any 32) `shouldBe` 32
+      it "bitSizeMaybe" $ do
+          bitSizeMaybe (range broadcast 0) `shouldBe` Just 0
+          bitSizeMaybe (range broadcast 24) `shouldBe` Just 24
+          bitSizeMaybe (range broadcast 31) `shouldBe` Just 31
+      it "testBit" $ do
+        let prefix = range loopback 8
+        testBit prefix <$> [0..31] `shouldBe`
+          -- Note: final bit is False not True
+          [ False, True,  True,  True,  True,  True,  True,  True
+          , False, False, False, False, False, False, False, False
+          , False, False, False, False, False, False, False, False
+          , False, False, False, False, False, False, False, False]
+      it "bit" $ do
+        bit 0 `shouldBe` range (ipv4 128 0 0 0) 1
+        bit 1 `shouldBe` range (ipv4 64 0 0 0) 2
+        bit 31 `shouldBe` range (ipv4 0 0 0 1) 32
+      it "popCount" $ do
+        popCount (range any 0) `shouldBe` 0
+        popCount (range broadcast 0) `shouldBe` 0
+        popCount (range loopback 8) `shouldBe` 7
+        popCount (range loopback 32) `shouldBe` 8
+    context "operates on network bits only" $ do
+      it "bitwise: same length" $ do
+        (IPv4Range broadcast 16) .&. (IPv4Range broadcast 16)
+          `shouldBe` (IPv4Range (ipv4 255 255 0 0) 16)
+      it "bitwise: differing lengths ignoring host bits" $ do
+        (IPv4Range broadcast 8) .&. (IPv4Range broadcast 16)
+          `shouldBe` (IPv4Range (ipv4 255 0 0 0) 16)
+      it "rebase: ignores host bits" $ do
+        complement (IPv4Range loopback 16)
+          `shouldBe` (IPv4Range (ipv4 128 255 0 0) 16)
+  describe "FiniteBits" $ do
+    it "finiteBitSize" $ do
+      finiteBitSize . (range loopback) <$> [0..31] `shouldBe` [0..31]


### PR DESCRIPTION
I had a little think over how the bitwise operations should be implemented and settled on acting purely on network bits removing (normalising) host bits. An alternative might be to operate on the whole IP as suggested in issue #30.

Justification:

I opted for only operating on the network bits because the IPv4Range's primary function is to specify networks. While host bits may be non-zero, this is a definitely a secondary use. The end result means you can use the functions without having to think about the host bits before whereas you'd have to look at normalising them before and after each operation.

In scenarios where you do care about host bits you are most likely already placing special care on how they're treated. In Haskell, you would probably want a different type that puts this information in the type system.

Testing:

In addition to the tests I have begun using this library in my code and it works as expected.

I hope you like it!