### PR TITLE
Improve IPv6 parser performance/simplicity

### DIFF
--- a/test/Test.hs
+++ b/test/Test.hs
@@ -270,47 +270,48 @@ testIPv6ParserFailure = do
 testIPv6Encode :: Assertion
 testIPv6Encode = do
 
-    -- degenerate cases:
-    "::" `roundTripsTo` "::"
-    "1234::" `roundTripsTo` "1234::"
-    "::1234" `roundTripsTo` "::1234"
+  -- degenerate cases:
+  "::" `roundTripsTo` "::"
+  "1234::" `roundTripsTo` "1234::"
+  "::1234" `roundTripsTo` "::1234"
 
-    -- zero-compression works:
-    "1234:1234:0000:0000:0000:0000:3456:3434" `roundTripsTo` "1234:1234::3456:3434"
+  -- zero-compression works:
+  "1234:1234:0000:0000:0000:0000:3456:3434" `roundTripsTo` "1234:1234::3456:3434"
 
-    -- picks first case:
-    "1234:0000:1234:0000:1234:0000:0123:1234" `roundTripsTo` "1234::1234:0:1234:0:123:1234"
+  -- picks first case:
+  "1234:0000:1234:0000:1234:0000:0123:1234" `roundTripsTo` "1234::1234:0:1234:0:123:1234"
 
-    -- picks longest case:
-    "1234:0000:1234:0000:0:0000:0123:1234" `roundTripsTo` "1234:0:1234::123:1234"
+  -- picks longest case:
+  "1234:0000:1234:0000:0:0000:0123:1234" `roundTripsTo` "1234:0:1234::123:1234"
 
-    -- can exclude all but first and last:
-    "1234::1234" `roundTripsTo` "1234::1234"
+  -- can exclude all but first and last:
+  "1234::1234" `roundTripsTo` "1234::1234"
 
-    -- prefers leftmost part to zero-compress:
-    "1:2:0:0:5::8" `roundTripsTo` "1:2::5:0:0:8"
+  -- prefers leftmost part to zero-compress:
+  "1:2:0:0:5::8" `roundTripsTo` "1:2::5:0:0:8"
 
-    -- can work with no zeroes:
-    "1:2:3:4:5:6:7:8" `roundTripsTo` "1:2:3:4:5:6:7:8"
+  -- can work with no zeroes:
+  "1:2:3:4:5:6:7:8" `roundTripsTo` "1:2:3:4:5:6:7:8"
 
-    -- works with only first or last:
-    "::2:3:4:5:6:7:8" `roundTripsTo` "::2:3:4:5:6:7:8"
-    "1:2:3:4:5:6:7::" `roundTripsTo` "1:2:3:4:5:6:7::"
+  -- works with only first or last:
+  "::2:3:4:5:6:7:8" `roundTripsTo` "::2:3:4:5:6:7:8"
+  "1:2:3:4:5:6:7::" `roundTripsTo` "1:2:3:4:5:6:7::"
 
-    -- decimal notation in IPv6 addresses:
-    "1:2:3:4:5:6:0.7.0.8" `roundTripsTo` "1:2:3:4:5:6:7:8"
-    "::0.0.0.0" `roundTripsTo` "::"
+  -- decimal notation in IPv6 addresses:
+  "1:2:3:4:5:6:0.7.0.8" `roundTripsTo` "1:2:3:4:5:6:7:8"
+  "::0.0.0.0" `roundTripsTo` "::"
 
-    -- per https://tools.ietf.org/html/rfc5952#section-5
-    "::ffff:0:0" `roundTripsTo` "::ffff:0.0.0.0"
-    "::ffff:00ff:ff00" `roundTripsTo` "::ffff:0.255.255.0"
-    "::ffff:203.0.113.17" `roundTripsTo` "::ffff:203.0.113.17"
+  -- per https://tools.ietf.org/html/rfc5952#section-5
+  "::ffff:0:0" `roundTripsTo` "::ffff:0.0.0.0"
+  "::ffff:00ff:ff00" `roundTripsTo` "::ffff:0.255.255.0"
+  "::ffff:203.0.113.17" `roundTripsTo` "::ffff:203.0.113.17"
+  "1234:5678::10.0.1.2" `roundTripsTo` "1234:5678::a00:102"
 
-   where
-   roundTripsTo s sExpected =
-     case AT.parseOnly (IPv6.parser <* AT.endOfInput) (Text.pack s) of
-        Right result -> IPv6.encode result @?= Text.pack sExpected
-        Left failMsg -> fail ("failed to parse '" ++ s ++ "': " ++ failMsg)
+ where
+ roundTripsTo s sExpected =
+   case AT.parseOnly (IPv6.parser <* AT.endOfInput) (Text.pack s) of
+      Right result -> IPv6.encode result @?= Text.pack sExpected
+      Left failMsg -> fail ("failed to parse '" ++ s ++ "': " ++ failMsg)
 
 textBadIPv4 :: [String]
 textBadIPv4 =

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -225,19 +225,36 @@ testIPv6ParserFailure = do
   go "1:::"
   go ":1::"
   go "::1:"
-  go "1:2:3:4:5:6:7:8:"
-  go ":1:2:3:4:5:6:7:8"
+  go "1:2:3:4:5:6:777:8:"
+  go ":1:2:3:4:5:6:7777:8"
 
   -- Incorrect numbers of parts:
-  go "1111:2222:3333:4444:5555:6666::7777:8888"
+  go ""
+  go "1111"
+  go "1111:2222"
+  go "1111:2222:3333"
+  go "1111:2222:3333:4444"
+  go "1111:2222:3333:4444:5555"
+  go "1111:2222:3333:4444:5555:6666"
+  go "1111:2222:3333:4444:5555:6666:7777"
   go "1111:2222:3333:4444:5555:6666:7777:8888:9999"
-  go "1111:2222:3333:4444:5555:6666:7777:8888::9999"
+
+  -- Incorrect use of double-colon:
+  go "1111::2222::3333"
+  go "1111:2222:3333:4444:5555:6666::7777:8888" -- not needed
+  go "1111:2222:3333:4444:5555:6666:7777:8888::9999" -- too long
 
   -- IPv4 decimal embedded, with not enough parts:
   go "1:127.0.0.1"
   go "1:2:3:127.0.0.1"
   go "1:2:3:4:127.0.0.1"
   go "1:2:3:4:5:127.0.0.1"
+
+  -- IPv4 decimal before double-colon:
+  go "1:127.0.0.1::"
+
+  -- Only IPv4:
+  go "127.0.0.1"
 
   -- IPv4 decimal embedded, with too many parts:
   go "1:2:3:4:5:6:7:127.0.0.1"
@@ -248,8 +265,7 @@ testIPv6ParserFailure = do
     @=? bimap (\_ -> ()) HexIPv6
       (AT.parseOnly
         (IPv6.parser <* AT.endOfInput)
-        (Text.pack str)
-      )
+        (Text.pack str))
 
 testIPv6Encode :: Assertion
 testIPv6Encode = do
@@ -294,7 +310,7 @@ testIPv6Encode = do
    roundTripsTo s sExpected =
      case AT.parseOnly (IPv6.parser <* AT.endOfInput) (Text.pack s) of
         Right result -> IPv6.encode result @?= Text.pack sExpected
-        Left failMsg -> fail failMsg -- parse shouldn't fail here
+        Left failMsg -> fail ("failed to parse '" ++ s ++ "': " ++ failMsg)
 
 textBadIPv4 :: [String]
 textBadIPv4 =


### PR DESCRIPTION
Since performance was slightly worsened by #37, I did some work to both simplify the IPv6 parser for understandability, and to make it faster.

All the main cases are now faster than the pre-#37 parser.

Here are the benchmark differences for this PR:

```
benchmarking IPv6 from Text/New '::'
time                 94.52 ns   (92.94 ns .. 96.27 ns)
                     0.996 R²   (0.994 R² .. 0.998 R²)
mean                 97.46 ns   (95.18 ns .. 102.9 ns)
std dev              11.55 ns   (7.396 ns .. 19.11 ns)
variance introduced by outliers: 93% (severely inflated)

benchmarking IPv6 from Text/Old '::'
time                 106.2 ns   (104.4 ns .. 108.9 ns)
                     0.995 R²   (0.991 R² .. 0.998 R²)
mean                 109.2 ns   (106.6 ns .. 113.9 ns)
std dev              11.28 ns   (7.229 ns .. 16.38 ns)
variance introduced by outliers: 91% (severely inflated)

benchmarking IPv6 from Text/New '1:2:3:4:5:6:7:8'
time                 570.5 ns   (566.2 ns .. 576.0 ns)
                     0.998 R²   (0.995 R² .. 0.999 R²)
mean                 594.5 ns   (580.0 ns .. 630.7 ns)
std dev              75.65 ns   (45.32 ns .. 124.5 ns)
variance introduced by outliers: 93% (severely inflated)

benchmarking IPv6 from Text/Old '1:2:3:4:5:6:7:8'
time                 954.7 ns   (946.1 ns .. 963.0 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 949.7 ns   (944.2 ns .. 955.7 ns)
std dev              19.29 ns   (16.17 ns .. 23.61 ns)
variance introduced by outliers: 24% (moderately inflated)

benchmarking IPv6 from Text/New '1:2::7:8'
time                 438.6 ns   (435.6 ns .. 441.9 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 439.3 ns   (436.9 ns .. 441.6 ns)
std dev              7.777 ns   (6.695 ns .. 9.178 ns)
variance introduced by outliers: 21% (moderately inflated)

benchmarking IPv6 from Text/Old '1:2::7:8'
time                 547.8 ns   (543.4 ns .. 552.9 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 547.1 ns   (543.8 ns .. 553.6 ns)
std dev              14.48 ns   (9.083 ns .. 27.68 ns)
variance introduced by outliers: 36% (moderately inflated)

benchmarking IPv6 from Text/New 'a:b::c:d'
time                 371.7 ns   (368.4 ns .. 375.7 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 370.5 ns   (368.2 ns .. 373.3 ns)
std dev              8.435 ns   (6.527 ns .. 12.45 ns)
variance introduced by outliers: 30% (moderately inflated)

benchmarking IPv6 from Text/Old 'a:b::c:d'
time                 428.0 ns   (425.4 ns .. 431.2 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 428.8 ns   (426.9 ns .. 430.7 ns)
std dev              6.405 ns   (5.121 ns .. 8.273 ns)
variance introduced by outliers: 15% (moderately inflated)
```