### PR TITLE
Use wide-word Word128 to implement IPv6 addresses.

### DIFF
--- a/changelog.markdown
+++ b/changelog.markdown
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## [1.5.0] - 2019-03-23
+- Implement `IPv6` using `wide-word`'s `Word128`. (This is a breaking change.)
+
 ## [1.4.2.1] - 2019-03-18
 - Docfix for `Net.IPv4.toList`
 

--- a/default.nix
+++ b/default.nix
@@ -25,6 +25,7 @@ let
     {
       ip = doBenchmark (build "ip" ./.);
       semirings = super.semirings_0_3_1_1;
+      wide-word = doJailbreak super.wide-word;
     };
   };
 in rec {

--- a/ip.cabal
+++ b/ip.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 name: ip
-version: 1.4.2.1
+version: 1.5.0
 synopsis: Library for IP and MAC addresses
 homepage: https://github.com/andrewthad/haskell-ip#readme
 license: BSD3

--- a/ip.cabal
+++ b/ip.cabal
@@ -55,6 +55,7 @@ library
     , primitive >= 0.6 && < 0.7
     , text >= 1.2  && < 1.3
     , vector >= 0.11 && < 0.13
+    , wide-word >= 0.1.0.8 && < 0.2
   ghc-options: -Wall -O2
   default-language: Haskell2010
 
@@ -65,6 +66,7 @@ test-suite test
   build-depends:
       base
     , ip
+    , wide-word
     , test-framework
     , test-framework-quickcheck2
     , QuickCheck
@@ -89,6 +91,7 @@ test-suite spec
   build-depends:
       base
     , ip
+    , wide-word
     , hspec >= 2.5.5
   other-modules:
     Net.IPv4Spec
@@ -104,6 +107,7 @@ test-suite doctest
   build-depends:
       base
     , ip
+    , wide-word
     , doctest >= 0.10
     , QuickCheck
   default-language:    Haskell2010

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -19,6 +19,7 @@ import Test.QuickCheck.Classes (Laws(..),jsonLaws,showReadLaws,bitsLaws,primLaws
 import qualified Test.Framework.Providers.HUnit as PH
 
 import Net.Types (IP,IPv4(..),IPv4Range(..),Mac(..),IPv6(..),MacGrouping(..),MacCodec(..),IPv6Range(..))
+import Data.WideWord (Word128(..))
 import qualified Data.Text as Text
 import qualified Data.ByteString.Char8 as BC8
 import qualified Net.IPv4 as IPv4
@@ -395,13 +396,15 @@ instance Show HexIPv6 where
 
 deriving instance Arbitrary IPv4
 
-instance Arbitrary IPv6 where
-  arbitrary = IPv6 <$> arbitrary <*> arbitrary
-  shrink (IPv6 a b) = filter (/= IPv6 a b)
-    [ IPv6 0 0
-    , IPv6 (div a 2) b
-    , IPv6 a (div b 2)
+instance Arbitrary Word128 where
+  arbitrary = Word128 <$> arbitrary <*> arbitrary
+  shrink (Word128 a b) = filter (/= Word128 a b)
+    [ Word128 0 0
+    , Word128 (div a 2) b
+    , Word128 a (div b 2)
     ]
+
+deriving instance Arbitrary IPv6
 
 -- Half of the test cases generated are IPv6 mapped
 -- IPv4 addresses.


### PR DESCRIPTION
There are probably a few opportunities to optimize this code further, or to simplify a few places with complicated masking, but I think this is a good start.

Performance is more-or-less the same as the original. In the few cases where using `Word128` was substantially slower, I adapted the existing `Word64`-based code. 

Here are the results of two benchmark runs on my machine:

Original:
```
benchmarking IPv6 to Text/New '::'
time                 74.68 ns   (74.11 ns .. 75.11 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 74.46 ns   (74.14 ns .. 74.89 ns)
std dev              1.255 ns   (970.3 ps .. 1.698 ns)
variance introduced by outliers: 21% (moderately inflated)

benchmarking IPv6 to Text/New '1:2:3:4:5:6:7:8'
time                 438.9 ns   (436.1 ns .. 441.9 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 442.5 ns   (440.5 ns .. 445.2 ns)
std dev              7.836 ns   (6.115 ns .. 11.15 ns)
variance introduced by outliers: 20% (moderately inflated)

benchmarking IPv6 to Text/New '1:2::7:8'
time                 332.2 ns   (330.7 ns .. 333.8 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 334.7 ns   (333.4 ns .. 336.0 ns)
std dev              4.180 ns   (3.319 ns .. 5.724 ns)
variance introduced by outliers: 12% (moderately inflated)

benchmarking IPv6 to Text/New 'a:b::c:d'
time                 273.9 ns   (272.5 ns .. 275.7 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 272.6 ns   (272.0 ns .. 273.4 ns)
std dev              2.269 ns   (1.611 ns .. 3.473 ns)

benchmarking IPv6 from Text/New '::'
time                 283.4 ns   (280.7 ns .. 286.9 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 286.2 ns   (284.0 ns .. 290.2 ns)
std dev              9.279 ns   (6.402 ns .. 13.62 ns)
variance introduced by outliers: 48% (moderately inflated)

benchmarking IPv6 from Text/New '1:2:3:4:5:6:7:8'
time                 1.398 μs   (1.392 μs .. 1.404 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.401 μs   (1.396 μs .. 1.407 μs)
std dev              16.88 ns   (14.00 ns .. 21.01 ns)

benchmarking IPv6 from Text/New '1:2::7:8'
time                 904.6 ns   (897.0 ns .. 916.0 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 904.0 ns   (898.0 ns .. 914.6 ns)
std dev              24.29 ns   (16.80 ns .. 33.40 ns)
variance introduced by outliers: 36% (moderately inflated)

benchmarking IPv6 from Text/New 'a:b::c:d'
time                 900.7 ns   (896.8 ns .. 905.0 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 907.9 ns   (903.0 ns .. 912.9 ns)
std dev              17.26 ns   (14.22 ns .. 21.13 ns)
variance introduced by outliers: 22% (moderately inflated)
```

New:
```
benchmarking IPv6 to Text/New '::'
time                 74.02 ns   (73.56 ns .. 74.43 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 74.15 ns   (73.87 ns .. 74.44 ns)
std dev              998.8 ps   (873.6 ps .. 1.176 ns)
variance introduced by outliers: 15% (moderately inflated)

benchmarking IPv6 to Text/New '1:2:3:4:5:6:7:8'
time                 447.5 ns   (444.4 ns .. 451.1 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 444.0 ns   (442.1 ns .. 445.8 ns)
std dev              6.508 ns   (4.977 ns .. 8.887 ns)
variance introduced by outliers: 15% (moderately inflated)

benchmarking IPv6 to Text/New '1:2::7:8'
time                 334.9 ns   (332.9 ns .. 337.6 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 337.0 ns   (335.0 ns .. 339.5 ns)
std dev              7.706 ns   (5.473 ns .. 10.67 ns)
variance introduced by outliers: 31% (moderately inflated)

benchmarking IPv6 to Text/New 'a:b::c:d'
time                 280.9 ns   (278.2 ns .. 283.5 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 281.3 ns   (279.6 ns .. 283.1 ns)
std dev              5.556 ns   (4.522 ns .. 7.357 ns)
variance introduced by outliers: 25% (moderately inflated)

benchmarking IPv6 from Text/New '::'
time                 279.7 ns   (278.8 ns .. 280.6 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 279.2 ns   (278.6 ns .. 279.9 ns)
std dev              2.161 ns   (1.850 ns .. 2.582 ns)

benchmarking IPv6 from Text/New '1:2:3:4:5:6:7:8'
time                 1.405 μs   (1.392 μs .. 1.419 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 1.402 μs   (1.394 μs .. 1.417 μs)
std dev              37.86 ns   (21.65 ns .. 64.50 ns)
variance introduced by outliers: 35% (moderately inflated)

benchmarking IPv6 from Text/New '1:2::7:8'
time                 871.9 ns   (869.8 ns .. 873.8 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 870.9 ns   (869.5 ns .. 872.5 ns)
std dev              4.591 ns   (3.735 ns .. 6.037 ns)

benchmarking IPv6 from Text/New 'a:b::c:d'
time                 900.5 ns   (896.0 ns .. 904.3 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 895.9 ns   (892.9 ns .. 899.6 ns)
std dev              11.45 ns   (9.356 ns .. 14.95 ns)
variance introduced by outliers: 11% (moderately inflated)
```
