### PR TITLE
Add even more efficient parsers for IPv4 addresses

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../small-bytearray-builder

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,0 @@
-packages: . ../small-bytearray-builder

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+source-repository-package
+  type: git
+  location: https://github.com/andrewthad/bytesmith
+  tag: 8ff120229ae2ccaadfd779cf774b6021a7bbfbfd

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,0 @@
-packages: .
-
-source-repository-package
-  type: git
-  location: https://github.com/andrewthad/bytesmith
-  tag: 8ff120229ae2ccaadfd779cf774b6021a7bbfbfd

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## [1.5.2] - 2019-??-??
+- Provide decode functions for decoding from `ShortText` and
+  from `Bytes`. These two are implemented internally using
+  the same function.
+- Dependency on `bytesmith` effectively restricts users to
+  GHC 8.6 and up. Since GHC 8.8 is about to be released,
+  this is deemed an acceptable cost.
+- Require cabal version 2.2 so that leading commas are accepted
+  in dependencies lists.
+
 ## [1.5.1] - 2019-07-29
 - Allow building with primitive-0.7.
 - Add more doctests to Net.IP.

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
-## [1.5.2] - 2019-??-??
+## [1.6.0] - 2019-??-??
 - Provide decode functions for decoding from `ShortText` and
   from `Bytes`. These two are implemented internally using
   the same function.

--- a/ip.cabal
+++ b/ip.cabal
@@ -50,7 +50,7 @@ library
     , attoparsec >= 0.13 && < 0.14
     , base >= 4.9.1.0 && < 5
     , byteslice >= 0.1.2 && < 0.2
-    , bytesmith >= 0.2.0.1 && < 0.3
+    , bytesmith >= 0.3 && < 0.4
     , bytestring >= 0.10.8 && < 0.11
     , deepseq >= 1.4 && < 1.5
     , hashable >= 1.2 && < 1.4

--- a/ip.cabal
+++ b/ip.cabal
@@ -47,17 +47,18 @@ library
     Data.ByteString.Builder.Fixed
   build-depends:
     , base >= 4.9.1.0 && < 5
-    , byteslice >= 0.1 && < 0.2
+    , byteslice >= 0.1.2 && < 0.2
     , bytesmith >= 0.1 && < 0.2
     , aeson >= 1.0 && < 1.5
     , attoparsec >= 0.13 && < 0.14
-    , bytestring >= 0.10 && < 0.11
+    , bytestring >= 0.10.8 && < 0.11
     , deepseq >= 1.4 && < 1.5
     , hashable >= 1.2 && < 1.4
     , primitive >= 0.6.4 && < 0.8
     , text >= 1.2  && < 1.3
     , vector >= 0.11 && < 0.13
     , wide-word >= 0.1.0.8 && < 0.2
+    , text-short >= 0.1.3 && < 0.2
   ghc-options: -Wall -O2
   default-language: Haskell2010
 

--- a/ip.cabal
+++ b/ip.cabal
@@ -48,7 +48,7 @@ library
   build-depends:
     , base >= 4.9.1.0 && < 5
     , byteslice >= 0.1.2 && < 0.2
-    , bytesmith >= 0.1 && < 0.2
+    , bytesmith >= 0.2 && < 0.3
     , aeson >= 1.0 && < 1.5
     , attoparsec >= 0.13 && < 0.14
     , bytestring >= 0.10.8 && < 0.11
@@ -72,15 +72,15 @@ test-suite test
       base
     , ip
     , wide-word
-    , test-framework
-    , test-framework-quickcheck2
+    , tasty
+    , tasty-quickcheck
+    , tasty-hunit
     , QuickCheck
     , quickcheck-classes >= 0.4.13 && < 0.7.0.0
     , text
     , text-short
     , bytestring
     , HUnit
-    , test-framework-hunit
     , attoparsec
     , byteslice >= 0.1.2 && < 0.2
   other-modules:

--- a/ip.cabal
+++ b/ip.cabal
@@ -57,7 +57,7 @@ library
     , natural-arithmetic >= 0.1 && <0.2
     , primitive >= 0.6.4 && < 0.8
     , small-bytearray-builder >= 0.2.1 && <0.3
-    , text >= 1.2  && < 1.3
+    , text >= 1.2 && < 1.3
     , text-short >= 0.1.3 && < 0.2
     , vector >= 0.11 && < 0.13
     , wide-word >= 0.1.0.8 && < 0.2

--- a/ip.cabal
+++ b/ip.cabal
@@ -34,33 +34,33 @@ description:
 library
   hs-source-dirs: src
   exposed-modules:
-    Net.Mac
+    Net.IP
     Net.IPv4
     Net.IPv6
-    Net.IP
+    Net.Mac
     Net.Types
   other-modules:
-    Data.Word.Synthetic.Word12
+    Data.ByteString.Builder.Fixed
+    Data.Text.Builder.Common.Internal
     Data.Text.Builder.Fixed
     Data.Text.Builder.Variable
-    Data.Text.Builder.Common.Internal
-    Data.ByteString.Builder.Fixed
+    Data.Word.Synthetic.Word12
   build-depends:
+    , aeson >= 1.0 && < 1.5
+    , attoparsec >= 0.13 && < 0.14
     , base >= 4.9.1.0 && < 5
     , byteslice >= 0.1.2 && < 0.2
     , bytesmith >= 0.2 && < 0.3
-    , aeson >= 1.0 && < 1.5
-    , attoparsec >= 0.13 && < 0.14
     , bytestring >= 0.10.8 && < 0.11
     , deepseq >= 1.4 && < 1.5
     , hashable >= 1.2 && < 1.4
+    , natural-arithmetic >= 0.1 && <0.2
     , primitive >= 0.6.4 && < 0.8
+    , small-bytearray-builder >= 0.2.1 && <0.3
     , text >= 1.2  && < 1.3
+    , text-short >= 0.1.3 && < 0.2
     , vector >= 0.11 && < 0.13
     , wide-word >= 0.1.0.8 && < 0.2
-    , text-short >= 0.1.3 && < 0.2
-    , small-bytearray-builder >= 0.2.1 && <0.3
-    , natural-arithmetic >= 0.1 && <0.2
   ghc-options: -Wall -O2
   default-language: Haskell2010
 
@@ -69,25 +69,25 @@ test-suite test
   hs-source-dirs:      test
   main-is:             Test.hs
   build-depends:
-      base
-    , ip
-    , wide-word
-    , tasty
-    , tasty-quickcheck
-    , tasty-hunit
+    , HUnit
     , QuickCheck
+    , attoparsec
+    , base
+    , byteslice >= 0.1.2 && < 0.2
+    , bytestring
+    , ip
     , quickcheck-classes >= 0.4.13 && < 0.7.0.0
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
     , text
     , text-short
-    , bytestring
-    , HUnit
-    , attoparsec
-    , byteslice >= 0.1.2 && < 0.2
+    , wide-word
   other-modules:
-    Naive
+    IPv4ByteString1
     IPv4Text1
     IPv4Text2
-    IPv4ByteString1
+    Naive
   ghc-options: -Wall -O2
   default-language: Haskell2010
 
@@ -96,13 +96,13 @@ test-suite spec
   hs-source-dirs: test
   main-is: Spec.hs
   build-depends:
-      base
+    , base
+    , hspec >= 2.5.5
     , ip
     , wide-word
-    , hspec >= 2.5.5
   other-modules:
-    Net.IPv4Spec
     Net.IPv4.RangeSpec
+    Net.IPv4Spec
   ghc-options: -Wall -O2
   default-language: Haskell2010
   build-tool-depends: hspec-discover:hspec-discover >= 2.5.5
@@ -112,30 +112,30 @@ test-suite doctest
   hs-source-dirs: test
   main-is: Doctests.hs
   build-depends:
-      base
+    , QuickCheck
+    , base
+    , doctest >= 0.10
     , ip
     , wide-word
-    , doctest >= 0.10
-    , QuickCheck
   default-language:    Haskell2010
 
 benchmark criterion
   type: exitcode-stdio-1.0
   build-depends:
-      base
-    , ip
-    , criterion
-    , text
-    , bytestring
     , attoparsec
+    , base
     , byteslice
+    , bytestring
+    , criterion
+    , ip
+    , text
   other-modules:
-    Naive
-    IPv4Text1
-    IPv4Text2
+    IPv4ByteString1
     IPv4DecodeText1
     IPv4DecodeText2
-    IPv4ByteString1
+    IPv4Text1
+    IPv4Text2
+    Naive
   ghc-options: -Wall -O2
   default-language: Haskell2010
   hs-source-dirs: test

--- a/ip.cabal
+++ b/ip.cabal
@@ -59,7 +59,7 @@ library
     , vector >= 0.11 && < 0.13
     , wide-word >= 0.1.0.8 && < 0.2
     , text-short >= 0.1.3 && < 0.2
-    , small-bytearray-builder >= 0.2 && <0.3
+    , small-bytearray-builder >= 0.2.1 && <0.3
     , natural-arithmetic >= 0.1 && <0.2
   ghc-options: -Wall -O2
   default-language: Haskell2010

--- a/ip.cabal
+++ b/ip.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: ip
-version: 1.5.2
+version: 1.6.0
 synopsis: Library for IP and MAC addresses
 homepage: https://github.com/andrewthad/haskell-ip#readme
 license: BSD-3-Clause

--- a/ip.cabal
+++ b/ip.cabal
@@ -77,6 +77,7 @@ test-suite test
     , QuickCheck
     , quickcheck-classes >= 0.4.13 && < 0.7.0.0
     , text
+    , text-short
     , bytestring
     , HUnit
     , test-framework-hunit

--- a/ip.cabal
+++ b/ip.cabal
@@ -59,6 +59,8 @@ library
     , vector >= 0.11 && < 0.13
     , wide-word >= 0.1.0.8 && < 0.2
     , text-short >= 0.1.3 && < 0.2
+    , small-bytearray-builder >= 0.2 && <0.3
+    , natural-arithmetic >= 0.1 && <0.2
   ghc-options: -Wall -O2
   default-language: Haskell2010
 
@@ -89,9 +91,9 @@ test-suite test
   default-language: Haskell2010
 
 test-suite spec
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
-  main-is:             Spec.hs
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Spec.hs
   build-depends:
       base
     , ip

--- a/ip.cabal
+++ b/ip.cabal
@@ -50,7 +50,7 @@ library
     , attoparsec >= 0.13 && < 0.14
     , base >= 4.9.1.0 && < 5
     , byteslice >= 0.1.2 && < 0.2
-    , bytesmith >= 0.2 && < 0.3
+    , bytesmith >= 0.2.0.1 && < 0.3
     , bytestring >= 0.10.8 && < 0.11
     , deepseq >= 1.4 && < 1.5
     , hashable >= 1.2 && < 1.4

--- a/ip.cabal
+++ b/ip.cabal
@@ -1,9 +1,9 @@
-cabal-version: 2.0
+cabal-version: 2.2
 name: ip
-version: 1.5.1
+version: 1.5.2
 synopsis: Library for IP and MAC addresses
 homepage: https://github.com/andrewthad/haskell-ip#readme
-license: BSD3
+license: BSD-3-Clause
 license-file: LICENSE
 author: Andrew Martin
 maintainer: andrew.thaddeus@gmail.com
@@ -46,7 +46,9 @@ library
     Data.Text.Builder.Common.Internal
     Data.ByteString.Builder.Fixed
   build-depends:
-      base >= 4.9.1.0 && < 5
+    , base >= 4.9.1.0 && < 5
+    , byteslice >= 0.1 && < 0.2
+    , bytesmith >= 0.1 && < 0.2
     , aeson >= 1.0 && < 1.5
     , attoparsec >= 0.13 && < 0.14
     , bytestring >= 0.10 && < 0.11
@@ -76,6 +78,7 @@ test-suite test
     , HUnit
     , test-framework-hunit
     , attoparsec
+    , byteslice >= 0.1.2 && < 0.2
   other-modules:
     Naive
     IPv4Text1
@@ -121,6 +124,7 @@ benchmark criterion
     , text
     , bytestring
     , attoparsec
+    , byteslice
   other-modules:
     Naive
     IPv4Text1

--- a/src/Net/IP.hs
+++ b/src/Net/IP.hs
@@ -39,6 +39,7 @@ module Net.IP
     -- * Textual Conversion
     -- ** Text
   , encode
+  , encodeShort
   , decode
     -- ** Printing
   , print
@@ -58,6 +59,7 @@ import Net.IPv6 (IPv6(..))
 import Prelude hiding (print)
 import Text.ParserCombinators.ReadPrec ((+++))
 import Text.Read (Read(..))
+import Data.Text.Short (ShortText)
 import qualified Data.Aeson as Aeson
 import qualified Data.Text.IO as TIO
 import qualified Net.IPv4 as IPv4
@@ -112,6 +114,10 @@ fromIPv6 = IP
 --   "3124::dead:cafe:ff:fe00:1"
 encode :: IP -> Text
 encode = case_ IPv4.encode IPv6.encode
+
+-- | Encode an 'IP' as 'ShortText'.
+encodeShort :: IP -> ShortText
+encodeShort = case_ IPv4.encodeShort IPv6.encodeShort
 
 -- | Decode an 'IP' from 'Text'.
 --

--- a/src/Net/IP.hs
+++ b/src/Net/IP.hs
@@ -72,6 +72,7 @@ import qualified Net.IPv6 as IPv6
 
 -- $setup
 -- >>> :set -XOverloadedStrings
+-- >>> import qualified Arithmetic.Nat as Nat
 
 -- | Run a function over an 'IP' depending on its status
 --   as an 'IPv4' or 'IPv6'.
@@ -131,6 +132,9 @@ encodeShort :: IP -> ShortText
 encodeShort = case_ IPv4.encodeShort IPv6.encodeShort
 
 -- | Encode an 'IP' as a bounded bytearray builder.
+--
+-- >>> BB.run Nat.constant (boundedBuilderUtf8 (ipv4 192 168 2 14))
+-- [0x31, 0x39, 0x32, 0x2e, 0x31, 0x36, 0x38, 0x2e, 0x32, 0x2e, 0x31, 0x34]
 boundedBuilderUtf8 :: IP -> BB.Builder 39
 boundedBuilderUtf8 = case_
   (\y -> BB.weaken Lte.constant (IPv4.boundedBuilderUtf8 y))

--- a/src/Net/IP.hs
+++ b/src/Net/IP.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 {-# OPTIONS_GHC -Wall #-}
@@ -41,6 +42,7 @@ module Net.IP
   , encode
   , encodeShort
   , decode
+  , boundedBuilderUtf8
     -- ** Printing
   , print
     -- * Types
@@ -60,7 +62,10 @@ import Prelude hiding (print)
 import Text.ParserCombinators.ReadPrec ((+++))
 import Text.Read (Read(..))
 import Data.Text.Short (ShortText)
+
+import qualified Arithmetic.Lte as Lte
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteArray.Builder.Bounded as BB
 import qualified Data.Text.IO as TIO
 import qualified Net.IPv4 as IPv4
 import qualified Net.IPv6 as IPv6
@@ -118,6 +123,12 @@ encode = case_ IPv4.encode IPv6.encode
 -- | Encode an 'IP' as 'ShortText'.
 encodeShort :: IP -> ShortText
 encodeShort = case_ IPv4.encodeShort IPv6.encodeShort
+
+-- | Encode an 'IP' as a bounded bytearray builder.
+boundedBuilderUtf8 :: IP -> BB.Builder 39
+boundedBuilderUtf8 = case_
+  (\y -> BB.weaken Lte.constant (IPv4.boundedBuilderUtf8 y))
+  IPv6.boundedBuilderUtf8
 
 -- | Decode an 'IP' from 'Text'.
 --

--- a/src/Net/IP.hs
+++ b/src/Net/IP.hs
@@ -121,6 +121,12 @@ encode :: IP -> Text
 encode = case_ IPv4.encode IPv6.encode
 
 -- | Encode an 'IP' as 'ShortText'.
+--
+--   >>> encodeShort (ipv4 10 0 1 26)
+--   "10.0.1.26"
+--
+--   >>> encodeShort (ipv6 0x3124 0x0 0x0 0xDEAD 0xCAFE 0xFF 0xFE01 0x0000)
+--   "3124::dead:cafe:ff:fe01:0"
 encodeShort :: IP -> ShortText
 encodeShort = case_ IPv4.encodeShort IPv6.encodeShort
 

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -417,7 +417,7 @@ byteArrayToShortByteString (PM.ByteArray x) = BSS.SBS x
 --   Just (ipv4 127 0 0 1)
 decodeUtf8Bytes :: Bytes.Bytes -> Maybe IPv4
 decodeUtf8Bytes !b = case Parser.parseBytes (parserUtf8Bytes ()) b of
-  Parser.Success addr len -> case len of
+  Parser.Success (Parser.Slice _ len addr) -> case len of
     0 -> Just addr
     _ -> Nothing
   Parser.Failure _ -> Nothing

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -41,11 +41,11 @@ module Net.IPv4
   , decodeUtf8
   , builderUtf8
   , parserUtf8
-  , byteArrayBuilderUtf8
-  , boundedBuilderUtf8
     -- ** UTF-8 Bytes
   , decodeUtf8Bytes
   , parserUtf8Bytes
+  , byteArrayBuilderUtf8
+  , boundedBuilderUtf8
     -- ** String
     -- $string
   , encodeString

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -120,6 +120,7 @@ import qualified Data.ByteString.Char8 as BC8
 import qualified Data.ByteString.Internal as I
 import qualified Data.ByteString.Unsafe as ByteString
 import qualified Data.ByteString.Short.Internal as BSS
+import qualified Data.Bytes as Bytes
 import qualified Data.Bytes.Parser as Parser
 import qualified Data.Bytes.Parser.Latin as Latin
 import qualified Data.Bytes as Bytes
@@ -379,6 +380,9 @@ decodeUtf8 = decode <=< rightToMaybe . decodeUtf8'
 -- as an intermediary.
 
 -- | Decode 'ShortText' as an 'IPv4' address.
+--
+--   >>> decodeShort "192.168.3.48"
+--   Just (ipv4 192 168 3 48)
 decodeShort :: ShortText -> Maybe IPv4
 decodeShort t = decodeUtf8Bytes (Bytes.fromByteArray b)
   where b = shortByteStringToByteArray (TS.toShortByteString t)
@@ -399,7 +403,10 @@ byteArrayToShortByteString :: PM.ByteArray -> BSS.ShortByteString
 byteArrayToShortByteString (PM.ByteArray x) = BSS.SBS x
 
 -- | Decode UTF-8-encoded 'Bytes' into an 'IPv4' address.
-decodeUtf8Bytes :: Bytes -> Maybe IPv4
+--
+--   >>> decodeUtf8Bytes (Bytes.fromAsciiString "127.0.0.1")
+--   Just (ipv4 127 0 0 1)
+decodeUtf8Bytes :: Bytes.Bytes -> Maybe IPv4
 decodeUtf8Bytes !b = case Parser.parseBytes (parserUtf8Bytes ()) b of
   Parser.Success addr len -> case len of
     0 -> Just addr

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -34,6 +34,7 @@ module Net.IPv4
   , builder
   , reader
   , parser
+  , decodeShort
     -- ** UTF-8 ByteString
   , encodeUtf8
   , decodeUtf8
@@ -93,6 +94,7 @@ import Data.Primitive.Types (Prim)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8')
 import Data.Text.Internal (Text(..))
+import Data.Text.Short (ShortText)
 import Data.Vector.Generic.Mutable (MVector(..))
 import Data.Word
 import Foreign.Ptr (Ptr,plusPtr)
@@ -112,7 +114,10 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as BC8
 import qualified Data.ByteString.Internal as I
 import qualified Data.ByteString.Unsafe as ByteString
+import qualified Data.ByteString.Short.Internal as BSS
 import qualified Data.Bytes.Parser as Smith
+import qualified Data.Bytes as Bytes
+import qualified Data.Primitive as PM
 import qualified Data.Text as Text
 import qualified Data.Text.Array as TArray
 import qualified Data.Text.IO as TIO
@@ -120,6 +125,7 @@ import qualified Data.Text.Lazy as LText
 import qualified Data.Text.Lazy.Builder as TBuilder
 import qualified Data.Text.Lazy.Builder.Int as TBI
 import qualified Data.Text.Read as TextRead
+import qualified Data.Text.Short as TS
 import qualified Data.Vector.Generic as GVector
 import qualified Data.Vector.Generic.Mutable as MGVector
 import qualified Data.Vector.Primitive as PVector
@@ -364,6 +370,14 @@ decodeUtf8 :: ByteString -> Maybe IPv4
 decodeUtf8 = decode <=< rightToMaybe . decodeUtf8'
 -- This (decodeUtf8) should be rewritten to not go through text
 -- as an intermediary.
+
+-- | Decode 'ShortText' as an 'IPv4' address.
+decodeShort :: ShortText -> Maybe IPv4
+decodeShort t = decodeUtf8Bytes (Bytes.fromByteArray b)
+  where b = shortByteStringToByteArray (TS.toShortByteString t)
+
+shortByteStringToByteArray :: BSS.ShortByteString -> PM.ByteArray
+shortByteStringToByteArray (BSS.SBS x) = PM.ByteArray x
 
 -- | Decode UTF-8-encoded 'Bytes' into an 'IPv4' address.
 decodeUtf8Bytes :: Bytes -> Maybe IPv4

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -120,7 +120,8 @@ import qualified Data.ByteString.Char8 as BC8
 import qualified Data.ByteString.Internal as I
 import qualified Data.ByteString.Unsafe as ByteString
 import qualified Data.ByteString.Short.Internal as BSS
-import qualified Data.Bytes.Parser as Smith
+import qualified Data.Bytes.Parser as Parser
+import qualified Data.Bytes.Parser.Latin as Latin
 import qualified Data.Bytes as Bytes
 import qualified Data.Primitive as PM
 import qualified Data.Text as Text
@@ -399,27 +400,27 @@ byteArrayToShortByteString (PM.ByteArray x) = BSS.SBS x
 
 -- | Decode UTF-8-encoded 'Bytes' into an 'IPv4' address.
 decodeUtf8Bytes :: Bytes -> Maybe IPv4
-decodeUtf8Bytes !b = case Smith.parseBytes (parserUtf8Bytes ()) b of
-  Smith.Success addr _ len -> case len of
+decodeUtf8Bytes !b = case Parser.parseBytes (parserUtf8Bytes ()) b of
+  Parser.Success addr len -> case len of
     0 -> Just addr
     _ -> Nothing
-  Smith.Failure _ -> Nothing
+  Parser.Failure _ -> Nothing
 
 -- | Parse UTF-8-encoded 'Bytes' as an 'IPv4' address.
-parserUtf8Bytes :: e -> Smith.Parser e s IPv4
+parserUtf8Bytes :: e -> Parser.Parser e s IPv4
 {-# inline parserUtf8Bytes #-}
-parserUtf8Bytes e = coerce (Smith.boxWord32 (parserUtf8Bytes# e))
+parserUtf8Bytes e = coerce (Parser.boxWord32 (parserUtf8Bytes# e))
 
-parserUtf8Bytes# :: e -> Smith.Parser e s Word#
+parserUtf8Bytes# :: e -> Parser.Parser e s Word#
 {-# noinline parserUtf8Bytes# #-}
-parserUtf8Bytes# e = Smith.unboxWord32 $ do
-  !a <- Smith.decWord8 e
-  Smith.ascii e '.'
-  !b <- Smith.decWord8 e
-  Smith.ascii e '.'
-  !c <- Smith.decWord8 e
-  Smith.ascii e '.'
-  !d <- Smith.decWord8 e
+parserUtf8Bytes# e = Parser.unboxWord32 $ do
+  !a <- Latin.decWord8 e
+  Latin.char e '.'
+  !b <- Latin.decWord8 e
+  Latin.char e '.'
+  !c <- Latin.decWord8 e
+  Latin.char e '.'
+  !d <- Latin.decWord8 e
   pure (getIPv4 (fromOctets a b c d))
 
 -- | Encode an 'IPv4' as a 'Builder.Builder'

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -417,6 +417,9 @@ decodeUtf8Bytes !b = case Parser.parseBytes (parserUtf8Bytes ()) b of
   Parser.Failure _ -> Nothing
 
 -- | Parse UTF-8-encoded 'Bytes' as an 'IPv4' address.
+--
+--   >>> Parser.parseBytes (parserUtf8Bytes ()) (Bytes.fromAsciiString "10.0.1.254")
+--   Success (ipv4 10 0 1 254) 0
 parserUtf8Bytes :: e -> Parser.Parser e s IPv4
 {-# inline parserUtf8Bytes #-}
 parserUtf8Bytes e = coerce (Parser.boxWord32 (parserUtf8Bytes# e))

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -92,7 +92,6 @@ import Data.ByteString (ByteString)
 import Data.Bytes.Types (Bytes)
 import Data.Coerce (coerce)
 import Data.Hashable
-import Data.Monoid ((<>))
 import Data.Primitive.Types (Prim)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8')

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -430,6 +430,7 @@ parserUtf8Bytes :: e -> Parser.Parser e s IPv4
 {-# inline parserUtf8Bytes #-}
 parserUtf8Bytes e = coerce (Parser.boxWord32 (parserUtf8Bytes# e))
 
+-- | Variant of 'parserUtf8Bytes' with unboxed result type.
 parserUtf8Bytes# :: e -> Parser.Parser e s IPv4#
 {-# noinline parserUtf8Bytes# #-}
 parserUtf8Bytes# e = Parser.unboxWord32 $ do

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -425,7 +425,7 @@ decodeUtf8Bytes !b = case Parser.parseBytes (parserUtf8Bytes ()) b of
 -- | Parse UTF-8-encoded 'Bytes' as an 'IPv4' address.
 --
 --   >>> Parser.parseBytes (parserUtf8Bytes ()) (Bytes.fromAsciiString "10.0.1.254")
---   Success (ipv4 10 0 1 254) 0
+--   Success (Slice {offset = 10, length = 0, value = ipv4 10 0 1 254})
 parserUtf8Bytes :: e -> Parser.Parser e s IPv4
 {-# inline parserUtf8Bytes #-}
 parserUtf8Bytes e = coerce (Parser.boxWord32 (parserUtf8Bytes# e))

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -89,7 +89,6 @@ import Data.Aeson (FromJSON(..),ToJSON(..))
 import Data.Aeson (ToJSONKey(..),FromJSONKey(..),ToJSONKeyFunction(..),FromJSONKeyFunction(..))
 import Data.Bits ((.&.),(.|.),shiftR,shiftL,unsafeShiftR,complement,shift)
 import Data.ByteString (ByteString)
-import Data.Bytes.Types (Bytes)
 import Data.Coerce (coerce)
 import Data.Hashable
 import Data.Primitive.Types (Prim)
@@ -123,7 +122,6 @@ import qualified Data.ByteString.Short.Internal as BSS
 import qualified Data.Bytes as Bytes
 import qualified Data.Bytes.Parser as Parser
 import qualified Data.Bytes.Parser.Latin as Latin
-import qualified Data.Bytes as Bytes
 import qualified Data.Primitive as PM
 import qualified Data.Text as Text
 import qualified Data.Text.Array as TArray

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -434,15 +434,28 @@ parserUtf8Bytes# e = Parser.unboxWord32 $ do
   !d <- Latin.decWord8 e
   pure (getIPv4 (fromOctets a b c d))
 
--- | Encode an 'IPv4' as a 'Builder.Builder'
+-- | Encode an 'IPv4' as a bytestring 'Builder.Builder'
+--
+-- >>> Builder.toLazyByteString (builderUtf8 (fromOctets 192 168 2 12))
+-- "192.168.2.12"
 builderUtf8 :: IPv4 -> Builder.Builder
 builderUtf8 = Builder.byteString . encodeUtf8
 
 -- | Encode an 'IPv4' address as a unbounded byte array builder.
+--
+-- >>> UB.run 1 (byteArrayBuilderUtf8 (fromOctets 192 168 2 13))
+-- [0x31, 0x39, 0x32, 0x2e, 0x31, 0x36, 0x38, 0x2e, 0x32, 0x2e, 0x31, 0x33]
+--
+-- Note that period is encoded by UTF-8 as @0x2e@.
 byteArrayBuilderUtf8 :: IPv4 -> UB.Builder
 byteArrayBuilderUtf8 = UB.fromBounded Nat.constant . boundedBuilderUtf8
 
 -- | Encode an 'IPv4' address as a bounded byte array builder.
+--
+-- >>> BB.run Nat.constant (boundedBuilderUtf8 (fromOctets 192 168 2 14))
+-- [0x31, 0x39, 0x32, 0x2e, 0x31, 0x36, 0x38, 0x2e, 0x32, 0x2e, 0x31, 0x34]
+--
+-- Note that period is encoded by UTF-8 as @0x2e@.
 boundedBuilderUtf8 :: IPv4 -> BB.Builder 15
 boundedBuilderUtf8 (IPv4 !w) =
   BB.word8Dec w1

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -388,6 +388,9 @@ decodeShort t = decodeUtf8Bytes (Bytes.fromByteArray b)
   where b = shortByteStringToByteArray (TS.toShortByteString t)
 
 -- | Encode an 'IPv4' address as 'ShortText'.
+--
+--   >>> encodeShort (ipv4 192 168 5 99)
+--   "192.168.5.99"
 encodeShort :: IPv4 -> ShortText
 encodeShort !w = id
   $ TS.fromShortByteStringUnsafe

--- a/src/Net/IPv6.hs
+++ b/src/Net/IPv6.hs
@@ -499,6 +499,9 @@ longestRun !w0 !w1 !w2 !w3 !w4 !w5 !w6 !w7 = id
 -- the leftmost longest string of zeroes in the address.
 -- Per <https://tools.ietf.org/html/rfc5952#section-5 RFC 5952 Section 5>,
 -- this uses mixed notation when encoding an IPv4-mapped IPv6 address.
+-- 
+-- >>> encodeShort $ fromWord16s 0xDEAD 0xBEEF 0x0 0x0 0x0 0x0ABC 0x0 0x1234
+-- "dead:beef::abc:0:1234"
 encodeShort :: IPv6 -> ShortText
 encodeShort w = id
   $ TS.fromShortByteStringUnsafe

--- a/src/Net/IPv6.hs
+++ b/src/Net/IPv6.hs
@@ -406,7 +406,7 @@ isIPv4Mapped (IPv6 (Word128 w1 w2)) =
 --   Just (ipv6 0x0000 0x0000 0x0000 0x0000 0x0000 0x0000 0x0cab 0x0001)
 decodeUtf8Bytes :: Bytes.Bytes -> Maybe IPv6
 decodeUtf8Bytes !b = case Parser.parseBytes (parserUtf8Bytes ()) b of
-  Parser.Success addr len -> case len of
+  Parser.Success (Parser.Slice _ len addr) -> case len of
     0 -> Just addr
     _ -> Nothing
   Parser.Failure _ -> Nothing

--- a/src/Net/IPv6.hs
+++ b/src/Net/IPv6.hs
@@ -561,7 +561,7 @@ decode t = rightToMaybe (AT.parseOnly (parser <* AT.endOfInput) t)
 --
 -- >>> let str = "dead:beef:3240:a426:ba68:1cd0:4263:109b -> alive"
 -- >>> Parser.parseBytes (parserUtf8Bytes ()) (Bytes.fromAsciiString str)
--- Success (ipv6 0xdead 0xbeef 0x3240 0xa426 0xba68 0x1cd0 0x4263 0x109b) 9
+-- Success (Slice {offset = 39, length = 9, value = ipv6 0xdead 0xbeef 0x3240 0xa426 0xba68 0x1cd0 0x4263 0x109b})
 --
 -- This does not currently support parsing embedded IPv4 address
 -- (e.g. @ff00:8000:abc::224.1.2.3@).

--- a/src/Net/IPv6.hs
+++ b/src/Net/IPv6.hs
@@ -381,6 +381,9 @@ isIPv4Mapped (IPv6 (Word128 w1 w2)) =
 
 -- | Encodes the 'IPv6' address using zero-compression on the
 -- leftmost longest string of zeroes in the address.
+--
+-- >>> BB.run Nat.constant $ boundedBuilderUtf8 $ fromWord16s 0xDEAD 0xBEEF 0x0 0x0 0x0 0x0 0x0 0x1234
+-- [0x64, 0x65, 0x61, 0x64, 0x3a, 0x62, 0x65, 0x65, 0x66, 0x3a, 0x3a, 0x31, 0x32, 0x33, 0x34]
 boundedBuilderUtf8 :: IPv6 -> BB.Builder 39
 boundedBuilderUtf8 !ip@(IPv6 (Word128 hi lo))
   | hi == 0 && lo == 0 = BB.weaken Lte.constant

--- a/src/Net/Mac.hs
+++ b/src/Net/Mac.hs
@@ -756,7 +756,6 @@ instance Hashable Mac
 instance ToJSON Mac where
   toJSON = Aeson.String . encode
 
-#if MIN_VERSION_aeson(1,0,0) 
 instance ToJSONKey Mac where
   toJSONKey = ToJSONKeyText
     encode
@@ -766,7 +765,6 @@ instance FromJSONKey Mac where
   fromJSONKey = FromJSONKeyTextParser $ \t -> case decode t of
     Nothing -> fail "invalid mac address"
     Just addr -> return addr
-#endif
 
 instance FromJSON Mac where
   parseJSON = attoparsecParseJSON parser

--- a/src/Net/Mac.hs
+++ b/src/Net/Mac.hs
@@ -60,7 +60,6 @@ import Data.Semigroup ((<>))
 #endif
 import Data.Text (Text)
 import Data.Word
-import Data.Word (Word8)
 import Data.Word.Synthetic.Word12 (Word12)
 import GHC.Enum (predError, succError)
 import GHC.Exts

--- a/test/Bench.hs
+++ b/test/Bench.hs
@@ -68,16 +68,21 @@ main = do
       , bench "Preallocated: No Lookup Tables" $ whnf IPv4ByteString1.encode ipAddr
       , bench "Preallocated" $ whnf IPv4.encodeUtf8 ipAddr
       ]
-    , bgroup "IPv6 to Text"
+    , bgroup "IPv6 from Text"
       [ bench "New '::'" $ whnf IPv6.decode ip6Text
       , bench "New '1:2:3:4:5:6:7:8'" $ whnf IPv6.decode ip6TextBigger
       , bench "New '1:2::7:8'" $ whnf IPv6.decode ip6TextSkip
       , bench "New 'a:b::c:d'" $ whnf IPv6.decode ip6TextHex
       ]
-    , bgroup "IPv6 from Text"
-      [ bench "New '::'" $ whnf IPv6.encode ip6
-      , bench "New '1:2:3:4:5:6:7:8'" $ whnf IPv6.encode ip6Bigger
-      , bench "New '1:2::7:8'" $ whnf IPv6.encode ip6Skip
-      , bench "New 'a:b::c:d'" $ whnf IPv6.encode ip6Hex
+    , bgroup "IPv6 to Text"
+      [ bench "::" $ whnf IPv6.encode ip6
+      , bench "1:2:3:4:5:6:7:8" $ whnf IPv6.encode ip6Bigger
+      , bench "1:2::7:8" $ whnf IPv6.encode ip6Skip
+      , bench "a:b::c:d" $ whnf IPv6.encode ip6Hex
+      ]
+    , bgroup "IPv6 to ShortText"
+      [ bench "1:2:3:4:5:6:7:8" $ whnf IPv6.encodeShort ip6Bigger
+      , bench "1:2::7:8" $ whnf IPv6.encodeShort ip6Skip
+      , bench "a:b::c:d" $ whnf IPv6.encodeShort ip6Hex
       ]
     ]

--- a/test/Bench.hs
+++ b/test/Bench.hs
@@ -27,6 +27,7 @@ main = do
       ip6 = fromJust $ IPv6.decode ip6Text
       ip6TextBigger = Text.pack "1:2:3:4:5:6:7:8"
       ip6Bigger = fromJust $ IPv6.decode ip6TextBigger
+      ip6Complicated = fromJust $ IPv6.decode (Text.pack "2001:db8:ba1:0:aaaa:542c:bb:cc00")
       ip6TextSkip = Text.pack "1:2::7:8"
       ip6Skip = fromJust $ IPv6.decode ip6TextSkip
       ip6TextHex = Text.pack "a:b::c:d"
@@ -84,5 +85,6 @@ main = do
       [ bench "1:2:3:4:5:6:7:8" $ whnf IPv6.encodeShort ip6Bigger
       , bench "1:2::7:8" $ whnf IPv6.encodeShort ip6Skip
       , bench "a:b::c:d" $ whnf IPv6.encodeShort ip6Hex
+      , bench "2001:db8:ba1:0:aaaa:542c:bb:cc00" $ whnf IPv6.encodeShort ip6Complicated
       ]
     ]

--- a/test/Bench.hs
+++ b/test/Bench.hs
@@ -46,6 +46,9 @@ main = do
       , bench "Current Implementation, no separator"
           $ whnf (Mac.encodeWithUtf8 (MacCodec MacGroupingNoSeparator True)) mac
       ]
+    , bgroup "IPv4 to ShortText"
+      [ bench "Implementation" $ whnf IPv4.encodeShort ipAddr
+      ]
     , bgroup "IPv4 to Text"
       [ bench "Naive" $ whnf Naive.encodeText ipAddr
       , bench "Text Builder" $ whnf IPv4Text2.encode ipAddr

--- a/test/Bench.hs
+++ b/test/Bench.hs
@@ -25,9 +25,13 @@ main = do
       mac = Mac.fromOctets 0xFA 0xBB 0x43 0xA1 0x22 0x09
       ip6Text = Text.pack "::"
       ip6 = fromJust $ IPv6.decode ip6Text
-      ip6TextBigger = Text.pack "1:2:3:4:5:6:7:8"
+      ip6StrBigger = "1:2:3:4:5:6:7:8"
+      ip6TextBigger = Text.pack ip6StrBigger
+      ip6BytesBigger = Bytes.fromAsciiString "1:2:3:4:5:6:7:8"
       ip6Bigger = fromJust $ IPv6.decode ip6TextBigger
-      ip6Complicated = fromJust $ IPv6.decode (Text.pack "2001:db8:ba1:0:aaaa:542c:bb:cc00")
+      ip6ComplicatedStr = "2001:db8:ba1:0:aaaa:542c:bb:cc00"
+      ip6ComplicatedBytes = Bytes.fromAsciiString ip6ComplicatedStr
+      ip6Complicated = fromJust $ IPv6.decode (Text.pack ip6ComplicatedStr)
       ip6TextSkip = Text.pack "1:2::7:8"
       ip6Skip = fromJust $ IPv6.decode ip6TextSkip
       ip6TextHex = Text.pack "a:b::c:d"
@@ -70,10 +74,14 @@ main = do
       , bench "Preallocated" $ whnf IPv4.encodeUtf8 ipAddr
       ]
     , bgroup "IPv6 from Text"
-      [ bench "New '::'" $ whnf IPv6.decode ip6Text
-      , bench "New '1:2:3:4:5:6:7:8'" $ whnf IPv6.decode ip6TextBigger
-      , bench "New '1:2::7:8'" $ whnf IPv6.decode ip6TextSkip
-      , bench "New 'a:b::c:d'" $ whnf IPv6.decode ip6TextHex
+      [ bench "::" $ whnf IPv6.decode ip6Text
+      , bench "1:2:3:4:5:6:7:8" $ whnf IPv6.decode ip6TextBigger
+      , bench "1:2::7:8" $ whnf IPv6.decode ip6TextSkip
+      , bench "a:b::c:d" $ whnf IPv6.decode ip6TextHex
+      ]
+    , bgroup "IPv6 bytesmith"
+      [ bench "1:2:3:4:5:6:7:8" $ whnf IPv6.decodeUtf8Bytes ip6BytesBigger
+      , bench "2001:db8:ba1:0:aaaa:542c:bb:cc00" $ whnf IPv6.decodeUtf8Bytes ip6ComplicatedBytes
       ]
     , bgroup "IPv6 to Text"
       [ bench "::" $ whnf IPv6.encode ip6

--- a/test/Bench.hs
+++ b/test/Bench.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Criterion.Main
 import Net.Types (IPv4(..),MacGrouping(..),MacCodec(..))
 import Data.Maybe (fromJust)
+import qualified Data.Bytes as Bytes
 import qualified Data.Text as Text
 import qualified Net.Mac as Mac
 import qualified Net.IPv4 as IPv4
@@ -20,6 +21,7 @@ main :: IO ()
 main = do
   let ipAddr = IPv4 1000000009
       ipText = Text.pack "192.168.5.99"
+      ipBytes = Bytes.fromAsciiString "192.168.5.99"
       mac = Mac.fromOctets 0xFA 0xBB 0x43 0xA1 0x22 0x09
       ip6Text = Text.pack "::"
       ip6 = fromJust $ IPv6.decode ip6Text
@@ -54,6 +56,9 @@ main = do
       [ bench "Naive" $ whnf Naive.decodeText ipText
       , bench "Attoparsec" $ whnf IPv4DecodeText2.decodeText ipText
       , bench "Text Reader" $ whnf IPv4DecodeText1.decodeText ipText
+      ]
+    , bgroup "IPv4 from Bytes"
+      [ bench "Current" $ whnf IPv4.decodeUtf8Bytes ipBytes
       ]
     , bgroup "IPv4 to ByteString"
       [ bench "Naive" $ whnf Naive.encodeByteString ipAddr

--- a/test/IPv4Text1.hs
+++ b/test/IPv4Text1.hs
@@ -2,7 +2,6 @@ module IPv4Text1 where
 
 import Net.Types (IPv4(..))
 import Data.Text (Text)
-import Data.Monoid ((<>))
 import Data.Text.Internal (Text(..))
 import Data.Word
 import Data.ByteString (ByteString)

--- a/test/IPv4Text2.hs
+++ b/test/IPv4Text2.hs
@@ -3,7 +3,6 @@ module IPv4Text2 where
 import Net.Types (IPv4(..))
 import Data.Text (Text)
 import Data.Bits ((.&.),shiftR)
-import Data.Monoid ((<>))
 import Data.Text.Lazy.Builder.Int (decimal)
 import qualified Data.Text.Lazy         as LText
 import qualified Data.Text.Lazy.Builder as TBuilder

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -9,15 +9,15 @@ import Naive
 import Control.Applicative (liftA2)
 import Data.Bytes (Bytes)
 import Data.Proxy (Proxy(..))
-import Test.Framework (defaultMain, testGroup, Test)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.Tasty (defaultMain, testGroup, TestTree)
+import Test.Tasty.QuickCheck (testProperty)
 import Test.QuickCheck (Arbitrary(..),Property,oneof,Gen,elements,choose,(===))
 import Test.HUnit (Assertion,(@?=),(@=?))
 import Numeric (showHex)
 import Test.QuickCheck.Property (failed,succeeded,Result(..))
 import Data.Bifunctor
 import Test.QuickCheck.Classes (Laws(..),jsonLaws,showReadLaws,bitsLaws,primLaws,boundedEnumLaws)
-import qualified Test.Framework.Providers.HUnit as PH
+import qualified Test.Tasty.HUnit as PH
 
 import Net.Types (IP,IPv4(..),IPv4Range(..),Mac(..),IPv6(..),MacGrouping(..),MacCodec(..),IPv6Range(..))
 import Data.WideWord (Word128(..))
@@ -41,8 +41,8 @@ import qualified IPv4ByteString1
 main :: IO ()
 main = defaultMain tests
 
-tests :: [Test]
-tests =
+tests :: TestTree
+tests = testGroup "tests"
   [ testGroup "Encoding and Decoding"
     [ testGroup "Currently used IPv4 encode/decode" $
       [ testProperty "Isomorphism"
@@ -161,7 +161,7 @@ tests =
     ]
   ]
 
-lawsToTest :: Laws -> Test
+lawsToTest :: Laws -> TestTree
 lawsToTest (Laws name pairs) = testGroup name (map (uncurry testProperty) pairs)
 
 propEncodeDecodeIso :: (Eq a, Show a, Show b)
@@ -373,7 +373,7 @@ textBadIPv4 =
   , "1.9"
   ]
 
-testDecodeFailures :: [Test]
+testDecodeFailures :: [TestTree]
 testDecodeFailures = flip map textBadIPv4 $ \str ->
   PH.testCase ("Should fail to decode [" ++ str ++ "]") $ IPv4.decode (Text.pack str) @?= Nothing
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -11,12 +11,12 @@ import Data.Bytes (Bytes)
 import Data.Proxy (Proxy(..))
 import Test.Tasty (defaultMain, testGroup, TestTree)
 import Test.Tasty.QuickCheck (testProperty)
-import Test.QuickCheck (Arbitrary(..),Property,oneof,Gen,elements,choose,(===))
+import Test.QuickCheck (Arbitrary(..),oneof,Gen,elements,choose,(===))
 import Test.HUnit (Assertion,(@?=),(@=?))
 import Numeric (showHex)
 import Test.QuickCheck.Property (failed,succeeded,Result(..))
 import Data.Bifunctor
-import Test.QuickCheck.Classes (Laws(..),jsonLaws,showReadLaws,bitsLaws,primLaws,boundedEnumLaws)
+import Test.QuickCheck.Classes (Laws(..),jsonLaws,showReadLaws,primLaws,boundedEnumLaws)
 import qualified Test.Tasty.HUnit as PH
 
 import Net.Types (IP,IPv4(..),IPv4Range(..),Mac(..),IPv6(..),MacGrouping(..),MacCodec(..),IPv6Range(..))

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -48,6 +48,10 @@ tests =
           $ propEncodeDecodeIso IPv4.encode IPv4.decode
       , PH.testCase "Decode an IP" testIPv4Decode
       ] ++ testDecodeFailures
+    , testGroup "Currently used IPv4 encodeShort/decodeShort" $
+      [ testProperty "Isomorphism"
+          $ propEncodeDecodeIso IPv4.encodeShort IPv4.decodeShort
+      ] ++ testDecodeFailures
     , testGroup "Currently used IPv4 UTF-8 Bytes decode"
       [ testProperty "Isomorphism"
           $ propEncodeDecodeIso (byteStringToBytes . IPv4.encodeUtf8) IPv4.decodeUtf8Bytes


### PR DESCRIPTION
A consequence of this PR is that the library will only support GHC 8.6 and up, but with GHC 8.8 around the corner, I'm not too worried about this. As I've become increasingly dissatisfied with `ByteString` and `Text`, I've turned to `text-short`, `text-utf8`, and `byteslice`. (Disclaimer: I wrote `byteslice`.) The goal is to support the types from these libraries as targets for encoding and decoding. This is currently blocked on https://github.com/andrewthad/bytesmith/issues/1.