### PR TITLE
New typeclass instances

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## [1.7.0] - 2019-10-28
+- Add `Data` instances for all types.
+- Add `Ix` instances for all address types.
+- Add missing `ToJSON`/`FromJSON` instances for `IPv6Range`.
+- Remove `Num`, `Integral`, and `Real` instances from `IPv6`.
+
 ## [1.6.0] - 2019-09-30
 - Provide decode functions for decoding from `ShortText` and
   from `Bytes`. These two are implemented internally using

--- a/src/Net/IP.hs
+++ b/src/Net/IP.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 
@@ -56,6 +57,8 @@ import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON(..),ToJSON(..))
 import Data.Bits
 import Data.Coerce (coerce)
+import Data.Data (Data)
+import Data.Ix (Ix)
 import Data.Text (Text)
 import Data.WideWord (Word128(..))
 import Data.Word (Word8,Word16)
@@ -222,7 +225,7 @@ print = TIO.putStrLn . encode
 --   of this type. All functions and typeclass methods that convert
 --   'IP' values to text will display it as an 'IPv4' address if possible.
 newtype IP = IP { getIP :: IPv6 }
-  deriving (Eq,Ord,Generic)
+  deriving (Eq,Ord,Generic,Ix,Data)
 
 instance NFData IP
 

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -97,7 +98,9 @@ import Data.Aeson (ToJSONKey(..),FromJSONKey(..),ToJSONKeyFunction(..),FromJSONK
 import Data.Bits ((.&.),(.|.),shiftR,shiftL,unsafeShiftR,complement,shift)
 import Data.ByteString (ByteString)
 import Data.Coerce (coerce)
+import Data.Data (Data)
 import Data.Hashable
+import Data.Ix (Ix)
 import Data.Primitive.Types (Prim)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8')
@@ -546,7 +549,7 @@ unbox (IPv4 (W32# w)) = w
 --   convert the underlying 'Word32' from host byte order to network byte
 --   order.
 newtype IPv4 = IPv4 { getIPv4 :: Word32 }
-  deriving (Eq,Ord,Enum,Bounded,Hashable,Generic,Prim,Storable)
+  deriving (Eq,Ord,Enum,Bounded,Hashable,Generic,Prim,Storable,Ix,Data)
 
 instance NFData IPv4
 
@@ -1074,7 +1077,7 @@ printRange = TIO.putStrLn . encodeRange
 data IPv4Range = IPv4Range
   { ipv4RangeBase   :: {-# UNPACK #-} !IPv4
   , ipv4RangeLength :: {-# UNPACK #-} !Word8
-  } deriving (Eq,Ord,Show,Read,Generic)
+  } deriving (Eq,Ord,Show,Read,Generic,Data)
 
 instance NFData IPv4Range
 instance Hashable IPv4Range

--- a/src/Net/IPv6.hs
+++ b/src/Net/IPv6.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
@@ -69,6 +70,8 @@ import Control.DeepSeq (NFData)
 import Control.Monad.ST (ST)
 import Data.Bits
 import Data.Char (chr)
+import Data.Data (Data)
+import Data.Ix (Ix)
 import Data.List (intercalate, group)
 import Data.Primitive (MutablePrimArray)
 import Data.Primitive.Types (Prim)
@@ -115,7 +118,7 @@ import qualified Net.IPv4 as IPv4
 
 -- | A 128-bit Internet Protocol version 6 address.
 newtype IPv6 = IPv6 { getIPv6 :: Word128 }
-  deriving (Bounded,Enum,Eq,Integral,Num,Ord,Real,Storable,Bits,FiniteBits,NFData,Prim)
+  deriving (Bounded,Enum,Eq,Integral,Num,Ord,Real,Storable,Bits,FiniteBits,NFData,Prim,Ix,Data)
 
 instance Show IPv6 where
   showsPrec p addr = showParen (p > 10)
@@ -749,7 +752,7 @@ parser = makeIP <$> ip
 data IPv6Range = IPv6Range
   { ipv6RangeBase   :: {-# UNPACK #-} !IPv6
   , ipv6RangeLength :: {-# UNPACK #-} !Word8
-  } deriving (Eq,Ord,Show,Read,Generic)
+  } deriving (Eq,Ord,Show,Read,Generic,Data)
 
 instance NFData IPv6Range
 

--- a/src/Net/IPv6.hs
+++ b/src/Net/IPv6.hs
@@ -119,7 +119,7 @@ import qualified Net.IPv4 as IPv4
 
 -- | A 128-bit Internet Protocol version 6 address.
 newtype IPv6 = IPv6 { getIPv6 :: Word128 }
-  deriving (Bounded,Enum,Eq,Integral,Num,Ord,Real,Storable,Bits,FiniteBits,NFData,Prim,Ix,Data)
+  deriving (Bounded,Enum,Eq,Ord,Storable,Bits,FiniteBits,NFData,Prim,Ix,Data)
 
 instance Show IPv6 where
   showsPrec p addr = showParen (p > 10)

--- a/src/Net/IPv6.hs
+++ b/src/Net/IPv6.hs
@@ -67,6 +67,7 @@ import Net.IPv4 (IPv4(..))
 
 import Control.Applicative
 import Control.DeepSeq (NFData)
+import Control.Monad (mzero)
 import Control.Monad.ST (ST)
 import Data.Bits
 import Data.Char (chr)
@@ -755,6 +756,15 @@ data IPv6Range = IPv6Range
   } deriving (Eq,Ord,Show,Read,Generic,Data)
 
 instance NFData IPv6Range
+
+instance Aeson.ToJSON IPv6Range where
+  toJSON = Aeson.String . encodeRange
+
+instance Aeson.FromJSON IPv6Range where
+  parseJSON (Aeson.String t) = case decodeRange t of
+    Nothing -> fail "Could not decodeRange IPv6 range"
+    Just res -> return res
+  parseJSON _ = mzero
 
 mask128 :: IPv6
 mask128 = maxBound

--- a/src/Net/Mac.hs
+++ b/src/Net/Mac.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
@@ -53,7 +54,9 @@ import Data.Aeson (ToJSONKeyFunction(..),FromJSONKeyFunction(..))
 import Data.Bits ((.|.),unsafeShiftL,unsafeShiftR,(.&.))
 import Data.ByteString (ByteString)
 import Data.Char (ord,chr)
+import Data.Data (Data)
 import Data.Hashable (Hashable)
+import Data.Ix (Ix)
 import Data.Primitive.Types (Prim(..))
 #if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup ((<>))
@@ -607,7 +610,7 @@ word12AtUtf8 i (Mac w) = fromIntegral (unsafeShiftR w i)
 --   type. It is not considered part of the stable API, and it
 --   allows you to construct invalid MAC addresses.
 newtype Mac = Mac Word64
-  deriving (Eq,Ord,Generic)
+  deriving (Eq,Ord,Generic,Ix,Data)
 
 instance NFData Mac
 
@@ -737,7 +740,7 @@ nibbleToHex w
 data MacCodec = MacCodec
   { macCodecGrouping :: !MacGrouping
   , macCodecUpperCase :: !Bool
-  } deriving (Eq,Ord,Show,Read,Generic)
+  } deriving (Eq,Ord,Show,Read,Generic,Data)
 
 -- | The format expected by the mac address parser. The 'Word8' taken
 --   by some of these constructors is the ascii value of the character
@@ -748,7 +751,7 @@ data MacGrouping
   | MacGroupingTriples !Char -- ^ Three-character groups, @24B-F0A-025-829@
   | MacGroupingQuadruples !Char -- ^ Four-character groups, @A220.0745.CAC7@
   | MacGroupingNoSeparator -- ^ No separator, @24AF4B5B0780@
-  deriving (Eq,Ord,Show,Read,Generic)
+  deriving (Eq,Ord,Show,Read,Generic,Data)
 
 instance Hashable Mac
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -159,6 +159,10 @@ tests = testGroup "tests"
       , lawsToTest (primLaws (Proxy :: Proxy IPv6))
       , lawsToTest (boundedEnumLaws (Proxy :: Proxy IPv6))
       ]
+    , testGroup "IPv6Range"
+      [ lawsToTest (jsonLaws (Proxy :: Proxy IPv6Range))
+      , lawsToTest (showReadLaws (Proxy :: Proxy IPv6Range))
+      ]
     , testGroup "IP"
       [ lawsToTest (jsonLaws (Proxy :: Proxy IP))
       , lawsToTest (showReadLaws (Proxy :: Proxy IP))


### PR DESCRIPTION
This series of commits adds `Data` and `Ix` typeclass instances to the address types; `Data` to the non-address types; and `FromJSON/ToJSON` to `IPv6Range`, which seems to have been overlooked.

It also removes `Integral`, `Num`, and `Real` to `IPv6`, which is the only address type to have these instances, as they don't make any sense for an IP address.
