### PR TITLE
Compile with base-4.15.0.0 (ghc-9.0.1)

### DIFF
--- a/src/Data/Word/Synthetic/Word12.hs
+++ b/src/Data/Word/Synthetic/Word12.hs
@@ -33,7 +33,12 @@ import           Data.Maybe
 import           GHC.Arr
 import           GHC.Base
 import           GHC.Enum
+#if MIN_VERSION_base(4,15,0)
+import           GHC.Integer (integerToWord, smallInteger)
+import           GHC.Num hiding (integerToWord)
+#else
 import           GHC.Num
+#endif
 import           GHC.Read
 import           GHC.Real
 import           GHC.Show


### PR DESCRIPTION
Nice to meet you!

This PR fixes compilation errors when compiling with ghc-9.0.1. The exported items of `GHC.Num` has changed (presumably [by a switch to `ghc-bignum`](https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/9.0.1-notes.html#highlights)), leading to a few errors.

Although the [haddock](https://hackage.haskell.org/package/base-4.15.0.0/docs/GHC-Num.html) (at the bottom of the page) claims that `GHC.Num` reexports `GHC.Integer`, in fact it doesn't. This PR adds conditional imports to keep using `GHC.Integer`.

I made sure `ip` compiles with previous ghc versions as old as 8.6.5:

```
cabal v2-build -w ghc-9.0.1
cabal v2-build -w ghc-8.10.7
cabal v2-build -w ghc-8.8.4 --constraint='contiguous<0.6'
cabal v2-build -w ghc-8.6.5 --constraint='contiguous<0.6'
```

The constraints on `contiguous` are due to https://github.com/andrewthad/contiguous/issues/45.