### PR TITLE
Support aeson-2.0*

### DIFF
--- a/ip.cabal
+++ b/ip.cabal
@@ -46,7 +46,7 @@ library
     Data.Text.Builder.Variable
     Data.Word.Synthetic.Word12
   build-depends:
-    , aeson >= 1.0 && < 1.6
+    , aeson >= 1.0 && < 2.1
     , attoparsec >= 0.13 && < 0.14
     , base >= 4.9 && < 5
     , byteslice >= 0.1.2 && < 0.3

--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -153,6 +153,10 @@ import qualified Data.Vector.Primitive as PVector
 import qualified Data.Vector.Unboxed as UVector
 import qualified Data.Vector.Unboxed.Mutable as MUVector
 
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as AesonKey
+#endif
+
 -- $setup
 --
 -- These are here to get doctest's property checking to work
@@ -697,8 +701,14 @@ instance FromJSON IPv4 where
 
 instance ToJSONKey IPv4 where
   toJSONKey = ToJSONKeyText
-    encode
+    (keyFromText . encode)
     (\addr -> Aeson.unsafeToEncoding $ Builder.char7 '"' <> builderUtf8 addr <> Builder.char7 '"')
+    where
+#if MIN_VERSION_aeson(2,0,0)
+      keyFromText = AesonKey.fromText
+#else
+      keyFromText = id
+#endif
 
 instance FromJSONKey IPv4 where
   fromJSONKey = FromJSONKeyTextParser aesonParser

--- a/src/Net/Mac.hs
+++ b/src/Net/Mac.hs
@@ -103,6 +103,10 @@ import qualified Data.Text.Lazy.Builder as TBuilder
 import qualified Data.Text.Short.Unsafe as TS
 import qualified Data.Text as Text ()
 
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as AK
+#endif
+
 -- $setup
 --
 -- These are here to get doctest's property checking to work
@@ -858,8 +862,14 @@ instance ToJSON Mac where
 
 instance ToJSONKey Mac where
   toJSONKey = ToJSONKeyText
-    encode
+    (keyFromText . encode)
     (\m -> Aeson.unsafeToEncoding $ BB.char7 '"' <> builderUtf8 m <> BB.char7 '"')
+    where
+#if MIN_VERSION_aeson(2,0,0)
+      keyFromText = AK.fromText
+#else
+      keyFromText = id
+#endif
 
 instance FromJSONKey Mac where
   fromJSONKey = FromJSONKeyTextParser $ \t -> case decode t of


### PR DESCRIPTION
There is one breaking change affecting this package, see
https://github.com/haskell/aeson/pull/868/files for details.
Old `aeson` versions are still supported since we are using CPP
to check the version.