### PR TITLE
Optimize readOctet function (#74)

### DIFF
--- a/src/Net/IPv4.hs
+++ b/src/Net/IPv4.hs
@@ -771,9 +771,8 @@ readOctet t = do
   where
   go :: Char -> (Int -> Maybe Int) -> Int -> Maybe Int
   go !d !f !n =
-    let d' = Char.ord d - 48
-        n' = n * 10 + d'
-    in  if d' >= 0 && d' <=9 && n' <= 255 then f n' else Nothing
+    let n' = n * 10 + Char.ord d - 48
+    in  if n' <= 255 then f n' else Nothing
 
 stripDecimal :: Text -> Either String Text
 stripDecimal t = case Text.uncons t of


### PR DESCRIPTION
All processed characters are guaranteed to be digits (0~9) through use of `Char.isDigit`, so the range check in helper function `go` is not necessary.