### PR TITLE
support for ghc9.2.1

### DIFF
--- a/ip.cabal
+++ b/ip.cabal
@@ -47,16 +47,16 @@ library
     Data.Word.Synthetic.Word12
   build-depends:
     , aeson >= 1.0 && < 2.1
-    , attoparsec >= 0.13 && < 0.14
+    , attoparsec >= 0.13
     , base >= 4.9 && < 5
     , byteslice >= 0.1.2 && < 0.3
-    , bytesmith >= 0.3.3 && < 0.4
-    , bytestring >= 0.10.8 && < 0.11
+    , bytesmith >= 0.3.3
+    , bytestring >= 0.10.8
     , deepseq >= 1.4 && < 1.5
     , hashable >= 1.2 && < 1.4
     , natural-arithmetic >= 0.1 && <0.2
     , primitive >= 0.6.4 && < 0.8
-    , bytebuild >= 0.3.4 && <0.4
+    , bytebuild >= 0.3.4 
     , text >= 1.2 && < 1.3
     , text-short >= 0.1.3 && < 0.2
     , vector >= 0.11 && < 0.13


### PR DESCRIPTION
I can build ip with 
- https://github.com/byteverse/bytebuild/pull/26
- https://github.com/byteverse/bytesmith/pull/22

I hate upperbounds in the haskell ecosystem but I can put them back if that's what it takes to get this merged.