### PR TITLE
[#79] Bump Dependency Upper-Bounds for Attoparsec & Hashable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ and this project adheres to the [Haskell Package Versioning Policy](https://pvp.
 
 - Add `boundedBuilderOctetsBE` and `boundedBuilderOctetsLE` to `Net.IPv4`.
 - Make doctests work again. Requires `doctest-0.20` or higher.
+- Bump upper bound on `attoparsec` to `< 0.15`.
+- Bump upper bound on `hashable` to `< 1.5`.
 
 ## [1.7.4] - 2021-12-28
 

--- a/ip.cabal
+++ b/ip.cabal
@@ -47,13 +47,13 @@ library
     Data.Word.Synthetic.Word12
   build-depends:
     , aeson >= 1.0 && < 2.1
-    , attoparsec >= 0.13 && < 0.14
+    , attoparsec >= 0.13 && < 0.15
     , base >= 4.9 && < 5
     , byteslice >= 0.1.2 && < 0.3
     , bytesmith >= 0.3.3 && < 0.4
     , bytestring >= 0.10.8 && < 0.11
     , deepseq >= 1.4 && < 1.5
-    , hashable >= 1.2 && < 1.4
+    , hashable >= 1.2 && < 1.5
     , natural-arithmetic >= 0.1 && <0.2
     , primitive >= 0.6.4 && < 0.8
     , bytebuild >= 0.3.4 && <0.4


### PR DESCRIPTION
Bump the maximum version bounds for the attoparsec & hashable packages.

I verified this using both cabal & stack LTS 19:

```sh
$ cabal new-test --constraint 'attoparsec>=0.14' --constraint 'hashable>=1.4'
1 of 1 test suites (1 of 1 test cases) passed.
$ stack build --fast --test -j$(nproc) --haddock --bench --no-run-benchmarks --resolver lts-19
All 165 tests passed (0.23s)
```

Can we get a metadata revision on hackage that reflects these changes? It would allow me to upgrade our code to LTS-19 :pray: 

Note that a new major version of bytestring is available, but it requires code changes so I will make a separate MR.

Fixes #79