### PR TITLE
Bumps text upper bound (<3)

### DIFF
--- a/ip.cabal
+++ b/ip.cabal
@@ -57,7 +57,7 @@ library
     , natural-arithmetic >= 0.1 && <0.2
     , primitive >= 0.6.4 && < 0.8
     , bytebuild >= 0.3.4 && <0.4
-    , text >= 1.2 && < 1.3
+    , text >= 1.2 && < 3
     , text-short >= 0.1.3 && < 0.2
     , vector >= 0.11 && < 0.13
     , wide-word >= 0.1.0.8 && < 0.2


### PR DESCRIPTION
I haven't tested this out locally (yet), so it's possible that this isn't quite safe seeing as `text >= 2.0` now has changed to a UTF-8 representation.