### PR TITLE
Bump `vector` Upper Bounds

### DIFF
--- a/ip.cabal
+++ b/ip.cabal
@@ -59,7 +59,7 @@ library
     , bytebuild >= 0.3.4 && <0.4
     , text >= 1.2 && < 1.3
     , text-short >= 0.1.3 && < 0.2
-    , vector >= 0.11 && < 0.13
+    , vector >= 0.11 && < 0.14
     , wide-word >= 0.1.1.2 && < 0.2
     , word-compat >= 0.0.4 && <0.1
   ghc-options: -Wall -O2


### PR DESCRIPTION
Tested on ghc 9.2 with:
```
cabal-3.8.1.0 new-test --disable-documentation --constraint 'vector>=0.13' -w ghc-9.2.3  
```

`text` could also use a bump but 2.0 changed from word16 to word8 so there are some code changes required: https://hackage.haskell.org/package/text-2.0.1/changelog