### PR TITLE
build with primitive 0.8

### DIFF
--- a/ip.cabal
+++ b/ip.cabal
@@ -56,7 +56,7 @@ library
     , deepseq >= 1.4 && < 1.5
     , hashable >= 1.2 && < 1.5
     , natural-arithmetic >= 0.1 && <0.2
-    , primitive >= 0.6.4 && < 0.8
+    , primitive >= 0.6.4 && < 0.9
     , bytebuild >= 0.3.4 && <0.4
     , text >= 1.2 && < 2.1
     , text-short >= 0.1.3 && < 0.2


### PR DESCRIPTION
```
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=wide-word:primitive --allow-newer=bytesmith:primitive --allow-newer=run-st:primitive --allow-newer=primitive-unlifted:primitive --allow-newer=contiguous:primitive --allow-newer=byteslice:primitive --allow-newer=tuples:primitive --allow-newer=primitive-addr:primitive --allow-newer=bytebuild:primitive --allow-newer=aeson:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - ip-1.7.7 (lib) (first run)
Configuring library for ip-1.7.7..
Preprocessing library for ip-1.7.7..
Building library for ip-1.7.7..
[ 1 of 11] Compiling Data.Text.Builder.Common.Compat ( src/Data/Text/Builder/Common/Compat.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/Text/Builder/Common/Compat.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/Text/Builder/Common/Compat.dyn_o )
[ 2 of 11] Compiling Data.Text.Builder.Common.Internal ( src/Data/Text/Builder/Common/Internal.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/Text/Builder/Common/Internal.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/Text/Builder/Common/Internal.dyn_o )
[ 3 of 11] Compiling Data.Text.Builder.Variable ( src/Data/Text/Builder/Variable.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/Text/Builder/Variable.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/Text/Builder/Variable.dyn_o )
[ 4 of 11] Compiling Data.Word.Synthetic.Word12 ( src/Data/Word/Synthetic/Word12.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/Word/Synthetic/Word12.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/Word/Synthetic/Word12.dyn_o )

src/Data/Word/Synthetic/Word12.hs:188:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral/Word8->Word12" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
188 | "fromIntegral/Word8->Word12"    fromIntegral = \x -> case x of { Compat.W8# y -> W12# y }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/Word/Synthetic/Word12.hs:189:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral/Word12->Word12" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
189 | "fromIntegral/Word12->Word12"   fromIntegral = id :: Word12 -> Word12
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/Word/Synthetic/Word12.hs:190:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral/Word12->Integer" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
190 | "fromIntegral/Word12->Integer"  fromIntegral = toInteger :: Word12 -> Integer
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/Word/Synthetic/Word12.hs:191:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral/a->Word12" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
191 | "fromIntegral/a->Word12"        fromIntegral = \x -> case fromIntegral x of W# x# -> W12# (narrow12Word# x#)
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/Word/Synthetic/Word12.hs:192:1: warning: [-Winline-rule-shadowing]
    Rule "fromIntegral/Word12->a" may never fire
      because ‘fromIntegral’ might inline first
    Suggested fix:
      Add an INLINE[n] or NOINLINE[n] pragma for ‘fromIntegral’
    |
192 | "fromIntegral/Word12->a"        fromIntegral = \(W12# x#) -> fromIntegral (W# x#)
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[ 5 of 11] Compiling Data.Text.Builder.Fixed ( src/Data/Text/Builder/Fixed.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/Text/Builder/Fixed.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/Text/Builder/Fixed.dyn_o )
[ 6 of 11] Compiling Data.ByteString.Builder.Fixed ( src/Data/ByteString/Builder/Fixed.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/ByteString/Builder/Fixed.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Data/ByteString/Builder/Fixed.dyn_o )
[ 7 of 11] Compiling Net.IPv4         ( src/Net/IPv4.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Net/IPv4.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Net/IPv4.dyn_o )
[ 8 of 11] Compiling Net.IPv6         ( src/Net/IPv6.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Net/IPv6.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Net/IPv6.dyn_o )
[ 9 of 11] Compiling Net.IP           ( src/Net/IP.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Net/IP.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Net/IP.dyn_o )
[10 of 11] Compiling Net.Mac          ( src/Net/Mac.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Net/Mac.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Net/Mac.dyn_o )
[11 of 11] Compiling Net.Types        ( src/Net/Types.hs, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Net/Types.o, /home/chessai/haskell/haskell-ip/dist-newstyle/build/x86_64-linux/ghc-9.4.4/ip-1.7.7/build/Net/Types.dyn_o )
```